### PR TITLE
feat: improve mobile hero and navigation

### DIFF
--- a/src/components/MobileNav.astro
+++ b/src/components/MobileNav.astro
@@ -1,0 +1,33 @@
+---
+// Mobile top navigation with hamburger menu
+const navItems = [
+  { href: "#hero", label: "Home" },
+  { href: "#evolution", label: "Experience" },
+  { href: "#projects", label: "Projects" },
+  { href: "#contact", label: "Contact" },
+];
+---
+<nav class="lg:hidden fixed top-0 left-0 w-full bg-warm-white/80 backdrop-blur-lg z-50" role="navigation" aria-label="Mobile navigation">
+  <div class="flex items-center justify-between px-4 h-16">
+    <span class="text-xl font-bold text-coral-primary">Shyam</span>
+    <button id="mobile-nav-toggle" class="p-2 text-text-dark" aria-label="Toggle navigation">
+      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+      </svg>
+    </button>
+  </div>
+  <div id="mobile-nav-menu" class="hidden flex-col items-center space-y-4 pb-4">
+    {navItems.map((item) => (
+      <a href={item.href} class="text-lg text-text-dark" onClick="document.getElementById('mobile-nav-menu').classList.add('hidden')">
+        {item.label}
+      </a>
+    ))}
+  </div>
+</nav>
+<script>
+  const toggle = document.getElementById('mobile-nav-toggle');
+  const menu = document.getElementById('mobile-nav-menu');
+  toggle.addEventListener('click', () => {
+    menu.classList.toggle('hidden');
+  });
+</script>

--- a/src/components/SidebarNav.astro
+++ b/src/components/SidebarNav.astro
@@ -44,7 +44,7 @@ const externalLinks = [
 ];
 ---
 
-<nav class="fixed left-0 top-0 h-full w-40 lg:w-48 z-50 pointer-events-none" role="navigation" aria-label="Main navigation">
+<nav class="hidden lg:block fixed left-0 top-0 h-full w-40 lg:w-48 z-50 pointer-events-none" role="navigation" aria-label="Main navigation">
 	<div class="h-full flex flex-col items-center justify-center space-y-8 pointer-events-auto">
 		<!-- Navigation container with organic progress bar -->
 		<div class="relative flex flex-col items-start">

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import "../styles/global.css";
 import SidebarNav from "../components/SidebarNav.astro";
+import MobileNav from "../components/MobileNav.astro";
 ---
 
 <!doctype html>
@@ -20,7 +21,8 @@ import SidebarNav from "../components/SidebarNav.astro";
 		<!-- Skip link for keyboard navigation -->
 		<a href="#main-content" class="skip-link">Skip to main content</a>
 		
-		<SidebarNav />
+                <MobileNav />
+                <SidebarNav />
 		<main id="main-content" role="main">
 			<slot />
 		</main>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,7 +25,7 @@ const projects = [
 
 <Layout>
 	<!-- Hero Section with Asymmetrical Layout -->
-	<section id="hero" class="h-[85vh] bg-warm-white relative overflow-hidden">
+        <section id="hero" class="min-h-screen lg:min-h-0 lg:h-[85vh] bg-warm-white relative overflow-hidden pt-20 lg:pt-0">
 		<!-- Organic background shapes -->
 		<div class="absolute inset-0 pointer-events-none">
 			<!-- Large coral blob -->
@@ -37,7 +37,7 @@ const projects = [
 		</div>
 
 		<!-- Asymmetrical grid layout -->
-		<div class="grid grid-cols-12 min-h-screen max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                <div class="grid grid-cols-12 min-h-screen lg:min-h-0 lg:h-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
 			<!-- Left side - 2/3 width for main content -->
 			<div class="col-span-12 lg:col-span-8 flex flex-col justify-center relative z-10">
 				<!-- Main heading with asymmetrical positioning -->


### PR DESCRIPTION
## Summary
- ensure hero section fills screen on mobile
- add a simple top mobile navigation
- hide sidebar navigation on small screens

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b78c573b9c8333a5eb9e286710c34c