### PR TITLE
fix(cta-button): allow extra classes

### DIFF
--- a/src/components/CTAButton.astro
+++ b/src/components/CTAButton.astro
@@ -3,12 +3,29 @@ export interface Props {
   href: string;
   variant?: string;
   children: any;
+  class?: string;
 }
 
-const { href, children, variant = "primary" } = Astro.props;
+const {
+  href,
+  children,
+  variant = "primary",
+  class: className
+} = Astro.props;
 ---
 
-<a class={`cta ${variant} u-glass u-glass--yellow u-r-xl u-elevate`} href={href}>
+<a
+  class:list={[
+    "cta",
+    variant,
+    "u-glass",
+    "u-glass--yellow",
+    "u-r-xl",
+    "u-elevate",
+    className
+  ]}
+  href={href}
+>
   {children}
 </a>
 


### PR DESCRIPTION
## Summary
- accept `class` prop in `CTAButton` and merge with base styles using `class:list`
- fix astro type check failing on missing `class` prop

## Testing
- `pnpm astro check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9320c30fc8333bae9cddf90a589f5