### PR TITLE
fix: Add sidebar margins to prevent content overlap

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -624,6 +624,21 @@ const projects = [
     }
   }
 
+  /* Add breathing room on desktop so content doesn't overlap the fixed sidebar */
+  @media (min-width: 1024px) {
+    .hero {
+      padding-left: calc(var(--sp-8) + 10rem);
+    }
+
+    .work-section {
+      padding-left: calc(var(--sp-16) + 10rem);
+    }
+
+    .timeline-section {
+      padding-left: calc(var(--sp-16) + 10rem);
+    }
+  }
+
   @media (max-width: 767px) {
     .hero {
       padding: var(--sp-6) var(--sp-6) var(--sp-8) var(--sp-6);


### PR DESCRIPTION
Add desktop-only left padding to main content sections to prevent overlap with the fixed sidebar navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-74582b44-d0a6-4370-a620-205040dc8a51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-74582b44-d0a6-4370-a620-205040dc8a51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

