### PR TITLE
Refactor one piece of messy code

### DIFF
--- a/src/components/ui/containers/GlassmorphicContainer.astro
+++ b/src/components/ui/containers/GlassmorphicContainer.astro
@@ -1,8 +1,8 @@
 ---
 // Component props interface
 export interface Props {
-  variant?: 'primary' | 'secondary' | 'neutral' | 'clear';
-  size?: 'small' | 'medium' | 'large';
+  variant?: Variant;
+  size?: Size;
   class?: string;
   tag?: 'div' | 'section' | 'article' | 'aside' | 'header' | 'footer';
 }
@@ -14,7 +14,7 @@ const {
   tag = 'div',
 } = Astro.props;
 
-import { getGlassmorphicClasses } from '../../../utils/glassmorphic';
+import { getGlassmorphicClasses, type Variant, type Size } from '../../../utils/glassmorphic';
 
 const allowedTags = {
   div: 'div',


### PR DESCRIPTION
refactor(GlassmorphicContainer): reuse glassmorphic variant and size types

## Summary

- **Problem:** The `GlassmorphicContainer.astro` component duplicated the `variant` and `size` literal union types that were already defined and exported in `utils/glassmorphic`.
- **Solution:** This PR refactors `GlassmorphicContainer.astro` to import and reuse the existing `Variant` and `Size` types from `utils/glassmorphic`, eliminating redundancy and improving type consistency.

## Screenshots/Recordings (if UI)

N/A

## Breaking Changes

None.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (if applicable)
- [ ] Docs updated (if applicable)

---
<a href="https://cursor.com/background-agent?bcId=bc-b2a2ec54-bd4a-4ea6-8a7b-6b18881d7e87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b2a2ec54-bd4a-4ea6-8a7b-6b18881d7e87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

