### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,4 +1,6 @@
 name: PR Checks
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/yamshy/portfolio/security/code-scanning/3](https://github.com/yamshy/portfolio/security/code-scanning/3)

To fix this problem, you should explicitly specify a `permissions` block in your workflow. The least privilege model recommends placing this at the workflow root, unless particular jobs need elevated permissions (which is not evident here). The minimal permission needed for most build/test workflows is `contents: read`. Add the following block at the workflow root (immediately after the `name` and before `on:`), or, if per-job permissions are required, add it to each job block (here: at both `node-checks` and `container-smoke-test`). The single best way is: *add the minimal `permissions` block at the root level* (after line 1), so all jobs inherit `contents: read`, unless they need more.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
