### PR TITLE
Add Organic Background on Mobile Devices

### DIFF
--- a/src/components/effects/organic/OrganicShapes.astro
+++ b/src/components/effects/organic/OrganicShapes.astro
@@ -23,10 +23,10 @@ import OrganicAnimations from './OrganicAnimations.astro';
     overflow: hidden;
   }
 
-  /* Hide on very small screens to avoid clutter */
+  /* Subtle presentation on very small screens instead of hiding */
   @media (max-width: 480px) {
     .organic-shapes {
-      display: none;
+      opacity: 0.7;
     }
   }
 


### PR DESCRIPTION
This pull request addresses issue #7 by updating the mobile background display. Instead of hiding the organic shapes on very small screens, we now set their opacity to 0.7, allowing for a subtle presence of the blobs. This enhancement improves the visual aesthetics of the mobile interface, ensuring it is not just a blank white background.

---

> This pull request was co-created with Cosine Genie

Original Task: [portfolio/aqqwujl5ey0n](https://cosine.sh/oz3q8e0atknt/portfolio/task/aqqwujl5ey0n)
Author: sajudia
