### PR TITLE
Improve Mobile Card Width for Better Usability

### DIFF
--- a/src/components/content/grids/BentoGrid.astro
+++ b/src/components/content/grids/BentoGrid.astro
@@ -99,8 +99,8 @@
     }
 
     .grid {
-      grid-template-columns: repeat(2, 1fr);
-      gap: var(--size-3);
+      grid-template-columns: 1fr;
+      gap: var(--size-4);
     }
 
     .grid :global(.card.featured),

--- a/src/components/content/timeline/Timeline.astro
+++ b/src/components/content/timeline/Timeline.astro
@@ -732,14 +732,18 @@
 
     /* Alternating widths and alignment */
     .node:nth-child(odd) .card,
+    .node:nth-child(odd) .badge,
+    .node:nth-child(even) .card,
+    .node:nth-child(even) .badge {
+      width: min(560px, calc(100% - var(--sp-8)));
+    }
+    .node:nth-child(odd) .card,
     .node:nth-child(odd) .badge {
-      width: min(420px, calc(50% - var(--sp-8)));
       margin-right: auto;
       margin-left: 0;
     }
     .node:nth-child(even) .card,
     .node:nth-child(even) .badge {
-      width: min(420px, calc(50% - var(--sp-8)));
       margin-left: auto;
       margin-right: 0;
     }
@@ -990,13 +994,17 @@
 
     /* Alternating widths and alignment (compact) */
     .node:nth-child(odd) .card,
+    .node:nth-child(odd) .badge,
+    .node:nth-child(even) .card,
+    .node:nth-child(even) .badge {
+      width: 100%;
+    }
+    .node:nth-child(odd) .card,
     .node:nth-child(odd) .badge {
-      width: calc(50% - var(--sp-6));
       margin-right: auto;
     }
     .node:nth-child(even) .card,
     .node:nth-child(even) .badge {
-      width: calc(50% - var(--sp-6));
       margin-left: auto;
     }
 


### PR DESCRIPTION
This pull request addresses issue #9, where the cards in the mobile experience were noted as being too narrow. The changes include adjusting the layout of the BentoGrid and Timeline components to increase the card widths. 

In `BentoGrid.astro`, the grid now uses a single column layout with a increased gap size. In `Timeline.astro`, the card widths have been modified to ensure they take up a greater portion of the screen, enhancing usability on mobile devices. These changes will provide a more user-friendly experience when browsing cards on smaller screens.

---

> This pull request was co-created with Cosine Genie

Original Task: [portfolio/x6f8h8z5izsr](https://cosine.sh/oz3q8e0atknt/portfolio/task/x6f8h8z5izsr)
Author: sajudia
