### PR TITLE
fix: enable pnpm via corepack in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,10 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 22
-      
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+          cache: pnpm
+
+      - name: Enable Corepack
+        run: corepack enable
       
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- enable corepack so pnpm is available in release workflow
- cache pnpm with setup-node
- run semantic-release via action

## Testing
- `pnpm astro check`
- `pnpm tsc --noEmit`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c521a2c2008333aa2400e95568c774