### PR TITLE
fix(ci): add missing pnpm setup step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           version: 10
       
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Problem

The release workflow was failing with the error:


## Solution

- Added the missing  step to the release workflow
- This ensures pnpm is properly installed and available before attempting to run Lockfile is up to date, resolution step is skipped
Already up to date


> portfolio@4.2.0 prepare /var/home/shyam/projects/portfolio
> husky

Done in 431ms using pnpm v10.15.0
- Maintains consistent Node.js version (20) across the workflow

## Testing

This should resolve the release workflow failures and allow semantic-release to run successfully.

Fixes the issue where the workflow was trying to use pnpm without having it installed first.