### PR TITLE
Remove Timeline Dots on Mobile Devices

### DIFF
--- a/src/components/content/timeline/Timeline.astro
+++ b/src/components/content/timeline/Timeline.astro
@@ -747,6 +747,12 @@
       margin-top: var(--sp-2);
     }
 
+    /* Remove timeline dots on mobile */
+    .node::before {
+      display: none !important;
+      content: none !important;
+    }
+
     /* Ensure SVG path is hidden on mobile */
     .path {
       display: none !important;
@@ -942,6 +948,12 @@
 
     .card p:first-child {
       margin-top: var(--sp-2);
+    }
+
+    /* Remove timeline dots on mobile (compact) */
+    .node::before {
+      display: none !important;
+      content: none !important;
     }
 
     /* Ensure SVG path is hidden on mobile */


### PR DESCRIPTION
This PR modifies the `Timeline.astro` component to remove the timeline dots on mobile devices. The dots, which are represented using `.node::before`, have been set to `display: none` and `content: none` for mobile view to improve the visual appearance. Additionally, similar changes have been made for compact mobile views to ensure consistency in the design across different screen sizes.

---

> This pull request was co-created with Cosine Genie

Original Task: [portfolio/3n0hw99tntm3](https://cosine.sh/oz3q8e0atknt/portfolio/task/3n0hw99tntm3)
Author: sajudia
