### PR TITLE
style: improve mobile scroll indicator spacing

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -689,7 +689,8 @@ const projects = [
       left: auto;
       bottom: auto;
       transform: none;
-      margin: var(--sp-6) auto 0 auto; /* breathing room below CTA stack */
+      margin: clamp(var(--sp-8), 8vw, var(--sp-12)) auto 0 auto; /* extra breathing room below CTA stack */
+      align-self: center; /* ensure indicator stays centered within flex column */
       animation-name: bounce-y; /* vertical-only bounce for static positioning */
     }
 


### PR DESCRIPTION
## Summary
- center the hero scroll indicator within the mobile flex column and increase the vertical spacing below the CTA buttons

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

![Mobile hero scroll indicator](browser:/invocations/phnrxmmy/artifacts/artifacts/mobile-hero-scroll-indicator.png)

------
https://chatgpt.com/codex/tasks/task_e_68cd8179c6c08333b8c225611205b9bf