### PR TITLE
fix: improve mobile timeline spacing

### DIFF
--- a/src/components/content/timeline/Timeline.astro
+++ b/src/components/content/timeline/Timeline.astro
@@ -568,7 +568,7 @@
     .phases {
       display: grid;
       grid-template-columns: 1fr;
-      gap: var(--sp-10);
+      gap: var(--sp-12);
       list-style: none;
       padding: 0;
       margin: 0;
@@ -755,7 +755,7 @@
     .phases {
       display: grid;
       grid-template-columns: 1fr;
-      gap: var(--sp-8);
+      gap: var(--sp-10);
       list-style: none;
       padding: 0;
       margin: 0;
@@ -885,7 +885,7 @@
     .badge {
       font-size: 0.8rem;
       display: block;
-      margin: 0 auto var(--sp-3);
+      margin: 0 auto var(--sp-4);
       text-align: center;
     }
 
@@ -896,7 +896,7 @@
       max-width: 24rem;
       margin-left: auto;
       margin-right: auto;
-      padding: var(--sp-5) var(--sp-4);
+      padding: var(--sp-6) var(--sp-4);
       min-height: 120px;
       position: relative;
     }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -579,11 +579,13 @@ const projects = [
     margin: 0 auto;
     padding: var(--size-8) !important;
     overflow: visible; /* allow inner timeline visuals to extend without clipping */
+    display: flex;
+    justify-content: center;
   }
 
   @media (max-width: 767px) {
     :global(.timeline-container) {
-      padding: var(--sp-4) var(--sp-2) !important;
+      padding: var(--sp-7) var(--sp-3) !important;
     }
   }
 
@@ -591,6 +593,20 @@ const projects = [
   :global(.timeline) {
     padding-inline-end: calc(var(--sp-10) + var(--sp-8)) !important;
     overflow: visible !important;
+  }
+
+  @media (max-width: 767px) {
+    .timeline-section {
+      padding: var(--sp-10) var(--sp-4);
+    }
+
+    :global(.timeline) {
+      padding-inline: var(--sp-3) !important;
+      padding-inline-end: var(--sp-3) !important;
+      padding-inline-start: var(--sp-3) !important;
+      margin-inline: auto;
+      max-width: 28rem;
+    }
   }
 
   .section-title {


### PR DESCRIPTION
## Summary
- rebalance the glass container padding so the timeline stays centered on narrow screens
- constrain the timeline width on mobile and remove the extra right padding to keep cards centered
- increase gaps and padding on compact timeline cards for better breathing room

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cd8809d8e4833395ca4d4891a3e067