### PR TITLE
refactor: optimize scroll progress tracking

### DIFF
--- a/src/utils/updateProgress.ts
+++ b/src/utils/updateProgress.ts
@@ -1,90 +1,143 @@
+const SECTION_IDS = ['about', 'work', 'evolution', 'contact'] as const;
+
+type SectionId = (typeof SECTION_IDS)[number];
+
+type NavSection = {
+  element: HTMLElement;
+  target: HTMLElement;
+};
+
+let cachedNavSections: NavSection[] | null = null;
+let cachedNavWrapper: HTMLElement | null = null;
+let cachedProgressBar: HTMLElement | null = null;
+
+const isInDocument = <T extends Element>(
+  element: T | null | undefined,
+): element is T => !!element && document.contains(element);
+
+const isSectionId = (value: string | undefined): value is SectionId =>
+  typeof value === 'string' &&
+  (SECTION_IDS as readonly string[]).includes(value);
+
+const resolveProgressBar = (): HTMLElement | null => {
+  if (isInDocument(cachedProgressBar)) {
+    return cachedProgressBar;
+  }
+
+  cachedProgressBar = document.getElementById('progress-bar');
+  return cachedProgressBar;
+};
+
+const resolveNavWrapper = (): HTMLElement | null => {
+  if (isInDocument(cachedNavWrapper)) {
+    return cachedNavWrapper;
+  }
+
+  cachedNavWrapper = document.querySelector<HTMLElement>('.nav-wrapper');
+  return cachedNavWrapper;
+};
+
+const resolveNavSections = (): NavSection[] => {
+  if (
+    cachedNavSections &&
+    cachedNavSections.every(
+      ({ element, target }) => isInDocument(element) && isInDocument(target),
+    )
+  ) {
+    return cachedNavSections;
+  }
+
+  const navElements = Array.from(
+    document.querySelectorAll<HTMLElement>('.nav-organic-button[data-section]'),
+  );
+
+  cachedNavSections = navElements
+    .map((element) => {
+      const sectionId = element.dataset.section;
+      if (!isSectionId(sectionId)) {
+        return null;
+      }
+
+      const target = document.getElementById(sectionId);
+      if (!isInDocument(target)) {
+        return null;
+      }
+
+      return { element, target } satisfies NavSection;
+    })
+    .filter(Boolean) as NavSection[];
+
+  return cachedNavSections;
+};
+
 export function updateProgress() {
-  const progressBar = document.getElementById('progress-bar');
-  const allNavElements = document.querySelectorAll('.nav-organic-button');
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return;
+  }
 
-  if (!progressBar || allNavElements.length === 0) return;
+  const progressBar = resolveProgressBar();
+  const navSections = resolveNavSections();
+  const allNavElements = Array.from(
+    document.querySelectorAll<HTMLElement>('.nav-organic-button'),
+  );
 
-  const scrollTop = window.pageYOffset;
+  if (!progressBar || navSections.length === 0 || allNavElements.length === 0) {
+    return;
+  }
 
-  const navOrder = [
-    {
-      selector: '.nav-organic-button[data-section="about"]',
-      target: '#about',
-    },
-    {
-      selector: '.nav-organic-button[data-section="work"]',
-      target: '#work',
-    },
-    {
-      selector: '.nav-organic-button[data-section="evolution"]',
-      target: '#evolution',
-    },
-    {
-      selector: '.nav-organic-button[data-section="contact"]',
-      target: '#contact',
-    },
-  ];
+  const scrollTop = window.scrollY;
+  const viewportOffset = window.innerHeight * 0.3;
+  const documentHeight = document.documentElement.scrollHeight;
 
   let progressPercentage = 0;
   let activeElement: HTMLElement | null = null;
 
-  navOrder.forEach((navItem, index) => {
-    const element = document.querySelector(navItem.selector);
-    if (!element) return;
+  for (let index = 0; index < navSections.length; index += 1) {
+    const { element, target } = navSections[index];
+    const targetPosition = target.offsetTop;
+    const nextTargetPosition =
+      navSections[index + 1]?.target.offsetTop ?? documentHeight;
 
-    const targetElement = document.querySelector(navItem.target);
-    if (!targetElement) return;
+    if (scrollTop >= nextTargetPosition - viewportOffset) {
+      progressPercentage = ((index + 1) / navSections.length) * 100;
+      continue;
+    }
 
-    const targetPosition = (targetElement as HTMLElement).offsetTop;
-    const nextTargetElement = navOrder[index + 1]
-      ? document.querySelector(navOrder[index + 1].target)
-      : null;
-    const nextTargetPosition = nextTargetElement
-      ? (nextTargetElement as HTMLElement).offsetTop
-      : document.documentElement.scrollHeight;
-
-    const viewportOffset = window.innerHeight * 0.3;
-
-    if (
-      scrollTop >= targetPosition - viewportOffset &&
-      scrollTop < nextTargetPosition - viewportOffset
-    ) {
+    if (scrollTop >= targetPosition - viewportOffset) {
       const sectionProgress = Math.min(
         (scrollTop - (targetPosition - viewportOffset)) /
-          (nextTargetPosition - targetPosition || 1),
+          Math.max(nextTargetPosition - targetPosition, 1),
         1,
       );
-      progressPercentage = ((index + sectionProgress) / navOrder.length) * 100;
-      activeElement = element as HTMLElement;
-    }
-  });
 
-  if (activeElement) {
-    const activeButton = (activeElement as HTMLElement).querySelector(
-      '.cell-nav-shape',
-    );
-    if (activeButton) {
-      const buttonRect = activeButton.getBoundingClientRect();
-      const navContainer = document.querySelector('.nav-wrapper');
-      if (navContainer) {
-        const containerRect = navContainer.getBoundingClientRect();
-        const relativeTop = buttonRect.top - containerRect.top;
-        const buttonCenter = relativeTop + buttonRect.height / 2;
-        const containerHeight = containerRect.height;
-        const centerPercentage = (buttonCenter / containerHeight) * 100;
-
-        progressBar.style.height = `${Math.min(centerPercentage, 100)}%`;
-      }
+      progressPercentage =
+        ((index + sectionProgress) / navSections.length) * 100;
+      activeElement = element;
+      break;
     }
-  } else {
-    progressBar.style.height = `${Math.min(progressPercentage, 100)}%`;
   }
+
+  const navWrapper = resolveNavWrapper();
+  const activeButton =
+    activeElement?.querySelector<HTMLElement>('.cell-nav-shape');
+
+  const progressHeight = (() => {
+    if (isInDocument(activeButton) && isInDocument(navWrapper)) {
+      const buttonRect = activeButton.getBoundingClientRect();
+      const containerRect = navWrapper.getBoundingClientRect();
+      const relativeTop = buttonRect.top - containerRect.top;
+      const buttonCenter = relativeTop + buttonRect.height / 2;
+      const containerHeight = containerRect.height || 1;
+
+      return Math.min((buttonCenter / containerHeight) * 100, 100);
+    }
+
+    return Math.min(progressPercentage, 100);
+  })();
+
+  progressBar.style.height = `${progressHeight}%`;
 
   allNavElements.forEach((element) => {
-    (element as HTMLElement).classList.remove('active');
+    element.classList.toggle('active', element === activeElement);
   });
-
-  if (activeElement) {
-    (activeElement as HTMLElement).classList.add('active');
-  }
 }


### PR DESCRIPTION
## Summary
- cache navigation elements and target sections when calculating the sidebar progress indicator
- reuse DOM queries and exit early when rendering context is unavailable to avoid runtime errors
- streamline active state handling while keeping the progress bar height in sync with the highlighted navigation item

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cd89f7d5e883339bef015d9dbfc500