### PR TITLE
chore: enable renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "assignees": ["{{{platform.repoOwner}}}"]
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- enable Renovate automerge for minor and patch updates to reduce manual maintenance
- remove the default Renovate assignee so dependency PRs are unassigned

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cd9d5026ac8333b47a1a6cdafc4c6d