### PR TITLE
fix: align contact email link with contact details

### DIFF
--- a/src/components/content/forms/ContactForm.astro
+++ b/src/components/content/forms/ContactForm.astro
@@ -47,7 +47,7 @@
 
   <div class="form-actions">
     <button type="submit" class="button button--primary">Send Message</button>
-    <a href="mailto:hello@yamshy.dev" class="button button--secondary"
+    <a href="mailto:mira@computational.bio" class="button button--secondary"
       >Email Instead</a
     >
   </div>


### PR DESCRIPTION
## Summary
- update the contact form's fallback email link to point at mira@computational.bio so it matches the published contact channels

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ce037380708333b3ae569d371d0076