### PR TITLE
fix: reduce hero spacing before subsequent sections

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -590,7 +590,8 @@ spec:
   }
 
   .hero {
-    padding-block: clamp(var(--space-xl), 10vh, var(--space-3xl));
+    padding-block-start: clamp(var(--space-xl), 10vh, var(--space-3xl));
+    padding-block-end: clamp(var(--space-lg), 6vh, var(--space-2xl));
   }
 
   .hero__inner {
@@ -679,7 +680,7 @@ spec:
   }
 
   .section {
-    padding-block: clamp(var(--space-xl), 12vh, var(--space-3xl));
+    padding-block: clamp(var(--space-lg), 8vh, var(--space-2xl));
   }
 
   .section__heading {


### PR DESCRIPTION
## Summary
- reduce the hero section's trailing padding so the next section appears sooner
- decrease default section padding to tighten vertical rhythm after the hero

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ce0c00d9c083338daaf5e9e1d26860