### PR TITLE
fix: remove phd honorific from header

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -220,7 +220,7 @@ spec:
 <BaseLayout>
   <header class="site-header u-container" data-reveal>
     <div class="site-header__brand">
-      <span class="u-pill">Shyam Ajudia, PhD</span>
+      <span class="u-pill">Shyam Ajudia</span>
       <p>
         Bioinformatics platform engineer translating molecular insights into
         resilient software.


### PR DESCRIPTION
## Summary
- remove the PhD honorific from the hero header pill so the site reflects the correct credentials

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ce1044bb848333a31171bee22e607c