### PR TITLE
fix: reveal sections sooner on mobile

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -549,21 +549,34 @@ spec:
 
   <script>
     const revealNodes = document.querySelectorAll('[data-reveal]');
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            entry.target.classList.add('is-revealed');
-            observer.unobserve(entry.target);
-          }
-        });
-      },
-      { threshold: 0.25 },
-    );
-    revealNodes.forEach((node) => {
-      node.classList.add('is-reveal-ready');
-      observer.observe(node);
-    });
+    const reduceMotionQuery =
+      'matchMedia' in window
+        ? window.matchMedia('(prefers-reduced-motion: reduce)')
+        : null;
+
+    if (reduceMotionQuery?.matches || !('IntersectionObserver' in window)) {
+      revealNodes.forEach((node) => {
+        node.classList.remove('is-reveal-ready');
+        node.classList.add('is-revealed');
+      });
+    } else {
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              entry.target.classList.add('is-revealed');
+              observer.unobserve(entry.target);
+            }
+          });
+        },
+        { threshold: 0 },
+      );
+
+      revealNodes.forEach((node) => {
+        node.classList.add('is-reveal-ready');
+        observer.observe(node);
+      });
+    }
   </script>
 </BaseLayout>
 


### PR DESCRIPTION
## Summary
- reduce the reveal observer threshold so sections fade in as soon as they enter the viewport, removing the long blank gap on mobile
- add graceful fallbacks for reduced-motion preference or browsers without IntersectionObserver support

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ce111ae6ec83338fe93115e3a304f0