### PR TITLE
feat: refresh hero metrics copy

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,22 +8,22 @@ import ApplicationSkills from '../components/skills/ApplicationSkills.svelte';
 
 const heroStats = [
   {
-    label: 'Clinical pipelines migrated',
-    value: '27',
+    label: 'Reliability engineered',
+    value: '24/7 uptime',
     context:
-      'production workloads moved from on-prem schedulers to portable Argo Workflows',
+      'Self-healing hybrid clusters with automated failover keeping research platforms continuously available',
   },
   {
-    label: 'Automation time saved',
-    value: '11.4k hrs',
+    label: 'Scale proven in production',
+    value: '10,000+ samples',
     context:
-      'wet-lab scientists regained annually via robotic QC and reproducible compute',
+      'Sequencing and analysis workloads orchestrated end-to-end without sacrificing reproducibility or compliance',
   },
   {
-    label: 'Data under stewardship',
-    value: '3.2 PB',
+    label: 'Efficiency unlocked',
+    value: '3,500+ hours saved',
     context:
-      'regulated genomic and phenotypic datasets under automated compliance controls',
+      'Systematic workflow automation reclaimed the equivalent of two FTEs across data processing and deployment',
   },
 ];
 


### PR DESCRIPTION
## Summary
- update the home hero metrics to emphasize reliability, scale, and efficiency outcomes
- highlight 24/7 uptime, 10,000+ samples processed, and 3,500+ hours of manual effort saved in the hero copy

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ce36f2512883339a2a1d9a70555b7f