### PR TITLE
fix: reveal content without scroll activation

### DIFF
--- a/src/layouts/CaseStudyLayout.astro
+++ b/src/layouts/CaseStudyLayout.astro
@@ -55,22 +55,76 @@ const {
     </div>
   </main>
   <script>
-    const revealNodes = document.querySelectorAll('[data-reveal]');
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            entry.target.classList.add('is-revealed');
-            observer.unobserve(entry.target);
-          }
+    const revealNodes = Array.from(document.querySelectorAll('[data-reveal]'));
+
+    if (revealNodes.length > 0) {
+      const rootElement = document.documentElement;
+      rootElement.removeAttribute('data-reveal-state');
+
+      const reduceMotionQuery =
+        'matchMedia' in window
+          ? window.matchMedia('(prefers-reduced-motion: reduce)')
+          : null;
+      const automationPattern =
+        /Headless|Playwright|Puppeteer|Chrome-Lighthouse|Speed\sInsights|Page Speed|Checkly|Screener|HeadlessShell/i;
+      const userAgent = navigator?.userAgent ?? '';
+      const isAutomationContext =
+        (typeof navigator !== 'undefined' && navigator.webdriver) ||
+        automationPattern.test(userAgent);
+
+      if (
+        reduceMotionQuery?.matches ||
+        !('IntersectionObserver' in window) ||
+        isAutomationContext
+      ) {
+        revealNodes.forEach((node) => {
+          node.classList.add('is-revealed', 'is-reveal-instant');
         });
-      },
-      { threshold: 0.25 },
-    );
-    revealNodes.forEach((node) => {
-      node.classList.add('is-reveal-ready');
-      observer.observe(node);
-    });
+      } else {
+        const observer = new IntersectionObserver(
+          (entries) => {
+            entries.forEach((entry) => {
+              if (entry.isIntersecting) {
+                entry.target.classList.add('is-revealed');
+                observer.unobserve(entry.target);
+              }
+            });
+          },
+          { threshold: 0.25, rootMargin: '0px 0px -10% 0px' },
+        );
+
+        const revealIfVisible = (node: Element) => {
+          const rect = node.getBoundingClientRect();
+          if (rect.bottom >= 0 && rect.top <= window.innerHeight) {
+            node.classList.add('is-revealed');
+            observer.unobserve(node);
+          }
+        };
+
+        revealNodes.forEach((node) => observer.observe(node));
+
+        const activateReveals = () => {
+          if (rootElement.dataset.revealState === 'active') {
+            return;
+          }
+
+          revealNodes.forEach(revealIfVisible);
+
+          requestAnimationFrame(() => {
+            rootElement.dataset.revealState = 'active';
+          });
+        };
+
+        if (window.scrollY > 0) {
+          activateReveals();
+        } else {
+          window.addEventListener('scroll', activateReveals, {
+            once: true,
+            passive: true,
+          });
+        }
+      }
+    }
   </script>
 </BaseLayout>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -538,34 +538,75 @@ spec:
   </main>
 
   <script>
-    const revealNodes = document.querySelectorAll('[data-reveal]');
-    const reduceMotionQuery =
-      'matchMedia' in window
-        ? window.matchMedia('(prefers-reduced-motion: reduce)')
-        : null;
+    const revealNodes = Array.from(document.querySelectorAll('[data-reveal]'));
 
-    if (reduceMotionQuery?.matches || !('IntersectionObserver' in window)) {
-      revealNodes.forEach((node) => {
-        node.classList.remove('is-reveal-ready');
-        node.classList.add('is-revealed');
-      });
-    } else {
-      const observer = new IntersectionObserver(
-        (entries) => {
-          entries.forEach((entry) => {
-            if (entry.isIntersecting) {
-              entry.target.classList.add('is-revealed');
-              observer.unobserve(entry.target);
-            }
+    if (revealNodes.length > 0) {
+      const rootElement = document.documentElement;
+      rootElement.removeAttribute('data-reveal-state');
+
+      const reduceMotionQuery =
+        'matchMedia' in window
+          ? window.matchMedia('(prefers-reduced-motion: reduce)')
+          : null;
+      const automationPattern =
+        /Headless|Playwright|Puppeteer|Chrome-Lighthouse|Speed\sInsights|Page Speed|Checkly|Screener|HeadlessShell/i;
+      const userAgent = navigator?.userAgent ?? '';
+      const isAutomationContext =
+        (typeof navigator !== 'undefined' && navigator.webdriver) ||
+        automationPattern.test(userAgent);
+
+      if (
+        reduceMotionQuery?.matches ||
+        !('IntersectionObserver' in window) ||
+        isAutomationContext
+      ) {
+        revealNodes.forEach((node) => {
+          node.classList.add('is-revealed', 'is-reveal-instant');
+        });
+      } else {
+        const observer = new IntersectionObserver(
+          (entries) => {
+            entries.forEach((entry) => {
+              if (entry.isIntersecting) {
+                entry.target.classList.add('is-revealed');
+                observer.unobserve(entry.target);
+              }
+            });
+          },
+          { threshold: 0.1, rootMargin: '0px 0px -10% 0px' },
+        );
+
+        const revealIfVisible = (node: Element) => {
+          const rect = node.getBoundingClientRect();
+          if (rect.bottom >= 0 && rect.top <= window.innerHeight) {
+            node.classList.add('is-revealed');
+            observer.unobserve(node);
+          }
+        };
+
+        revealNodes.forEach((node) => observer.observe(node));
+
+        const activateReveals = () => {
+          if (rootElement.dataset.revealState === 'active') {
+            return;
+          }
+
+          revealNodes.forEach(revealIfVisible);
+
+          requestAnimationFrame(() => {
+            rootElement.dataset.revealState = 'active';
           });
-        },
-        { threshold: 0 },
-      );
+        };
 
-      revealNodes.forEach((node) => {
-        node.classList.add('is-reveal-ready');
-        observer.observe(node);
-      });
+        if (window.scrollY > 0) {
+          activateReveals();
+        } else {
+          window.addEventListener('scroll', activateReveals, {
+            once: true,
+            passive: true,
+          });
+        }
+      }
     }
   </script>
 </BaseLayout>

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -104,7 +104,7 @@
     border: 0;
   }
 
-  .is-reveal-ready {
+  :root[data-reveal-state='active'] [data-reveal] {
     opacity: 0;
     transform: translateY(40px);
     transition:
@@ -112,9 +112,15 @@
       transform var(--duration-slow) var(--ease-emphatic);
   }
 
-  .is-revealed {
+  :root[data-reveal-state='active'] [data-reveal].is-revealed {
     opacity: 1;
     transform: translateY(0);
+  }
+
+  .is-reveal-instant {
+    opacity: 1 !important;
+    transform: translateY(0) !important;
+    transition: none !important;
   }
 
   @media (min-width: 72rem) {


### PR DESCRIPTION
## Summary
- wait to enable scroll-triggered reveals until the visitor interacts so preview captures render every section without scrolling
- keep automation and reduced-motion sessions visible by marking reveal nodes for instant display
- update shared utilities to drive reveal transitions from a root data attribute and instant-display helper class

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ce4370415c8333a4efb0e7a5b80a22