### PR TITLE
test: expand e2e coverage for home and case study

### DIFF
--- a/tests/e2e/case-studies.spec.ts
+++ b/tests/e2e/case-studies.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Adaptive NGS case study', () => {
+  test('surfaces hero metrics and interactive visualisations', async ({
+    page,
+  }) => {
+    await page.goto('/case-studies/adaptive-ngs');
+
+    await expect(
+      page.getByRole('heading', { name: 'Adaptive NGS Orchestrator' }),
+    ).toBeVisible();
+    await expect(page.locator('.case-study__metrics div')).toHaveCount(3);
+
+    await page.locator('#results').scrollIntoViewIfNeeded();
+    await expect(page.getByTestId('ic50-visualizer')).toBeVisible();
+
+    await page.locator('#operations').scrollIntoViewIfNeeded();
+    await expect(
+      page.getByRole('region', { name: 'Infrastructure health' }),
+    ).toBeVisible();
+  });
+
+  test('navigates to the case study from the home page hero CTA', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    const caseStudyLink = page.getByRole('link', {
+      name: 'View flagship case study',
+    });
+    await expect(caseStudyLink).toBeVisible();
+    await caseStudyLink.click();
+
+    await expect(page).toHaveURL(/\/case-studies\/adaptive-ngs/);
+    await expect(
+      page.getByRole('heading', { name: 'Adaptive NGS Orchestrator' }),
+    ).toBeVisible();
+  });
+});

--- a/tests/e2e/components.spec.ts
+++ b/tests/e2e/components.spec.ts
@@ -1,194 +1,109 @@
+import AxeBuilder from '@axe-core/playwright';
 import { test, expect } from '@playwright/test';
 
-test.describe('Component Integration Tests', () => {
+test.describe('Home page experience', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
   });
 
-  test('should render all main components', async ({ page }) => {
-    // Check for root document metadata
-    const rootDocument = page.locator('html');
-    await expect(rootDocument).toHaveAttribute('lang', 'en');
+  test('renders hero content and site navigation', async ({ page }) => {
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
 
-    // Primary header should be present
-    const siteHeader = page.locator('.site-header');
-    await expect(siteHeader).toBeVisible();
+    await expect(page.locator('.site-header')).toBeVisible();
+    await expect(page.getByRole('banner')).toBeVisible();
 
-    // Hero headline anchors the page
-    const heroTitle = page.locator('.hero__title');
-    await expect(heroTitle).toBeVisible();
+    await expect(page.locator('.hero__title')).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Collaborate' })).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: 'View flagship case study' }),
+    ).toBeVisible();
 
-    // Ensure at least one content section is rendered
-    const mainSection = page.locator('main section');
-    await expect(mainSection.first()).toBeVisible();
+    await expect(page.locator('.hero__metric')).toHaveCount(3);
   });
 
-  test('should have proper glassmorphic styling', async ({ page }) => {
-    // Look for glassmorphic containers
-    const glassElements = page.locator('.u-glass, .glassmorphic-container');
-    const glassCount = await glassElements.count();
+  test('displays featured projects and interactive modules', async ({
+    page,
+  }) => {
+    const projectsSection = page.locator('#projects');
+    await projectsSection.scrollIntoViewIfNeeded();
+    await expect(projectsSection).toBeVisible();
 
-    if (glassCount > 0) {
-      const firstGlass = glassElements.first();
-      await expect(firstGlass).toBeVisible();
+    await expect(page.locator('.projects__grid .project-card')).toHaveCount(6);
+    await expect(
+      page.getByRole('link', { name: 'Read research-style case study →' }),
+    ).toBeVisible();
 
-      // Should have some transparency/backdrop effects
-      // This is hard to test directly, but we can check the class is applied
-      const hasGlassClass = await firstGlass.getAttribute('class');
-      expect(hasGlassClass).toMatch(/glass/);
-    }
+    await expect(page.getByTestId('ic50-visualizer')).toBeVisible();
+    await expect(
+      page.getByRole('region', { name: 'Infrastructure health' }),
+    ).toBeVisible();
   });
 
-  test('should render project cards in work section', async ({ page }) => {
-    // Look for work/project section
-    const workSection = page.locator('#work, .bento');
+  test('highlights skills, experience, and contact sections', async ({
+    page,
+  }) => {
+    const skills = page.locator('#skills');
+    await skills.scrollIntoViewIfNeeded();
+    await expect(skills).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /Capabilities organised/i }),
+    ).toBeVisible();
 
-    if (await workSection.isVisible()) {
-      // Should have project cards
-      const projectCards = page.locator('.card, .project-card');
-      const cardCount = await projectCards.count();
+    const experience = page.locator('#experience');
+    await experience.scrollIntoViewIfNeeded();
+    await expect(experience).toBeVisible();
+    await expect(
+      page.getByRole('heading', {
+        name: /Career progression from research to technical operations leadership/i,
+      }),
+    ).toBeVisible();
 
-      if (cardCount > 0) {
-        const firstCard = projectCards.first();
-        await expect(firstCard).toBeVisible();
+    const insights = page.locator('#insights');
+    await insights.scrollIntoViewIfNeeded();
+    await expect(insights).toBeVisible();
+    await expect(
+      page.getByRole('heading', {
+        name: 'Operating principles for reproducible, scalable science',
+      }),
+    ).toBeVisible();
 
-        // Cards should have proper structure
-        const cardHeader = firstCard.locator('h3, .header h3');
-        if ((await cardHeader.count()) > 0) {
-          await expect(cardHeader.first()).toBeVisible();
-        }
-      }
-    }
+    const contact = page.locator('#contact');
+    await contact.scrollIntoViewIfNeeded();
+    await expect(contact).toBeVisible();
+    await expect(
+      page.getByRole('heading', {
+        name: 'Let’s design infrastructure that keeps pace with discovery',
+      }),
+    ).toBeVisible();
   });
 
-  test('should have working contact form', async ({ page }) => {
-    const contactForm = page.locator('form, .contact-form');
+  test('persists theme preference across reloads', async ({ page }) => {
+    const html = page.locator('html');
+    const initialTheme = (await html.getAttribute('data-theme')) ?? 'light';
 
-    if (await contactForm.isVisible()) {
-      // Should have form fields
-      const nameField = contactForm
-        .locator('input[name="name"], input[type="text"]')
-        .first();
-      const emailField = contactForm
-        .locator('input[name="email"], input[type="email"]')
-        .first();
-      const messageField = contactForm
-        .locator('textarea[name="message"], textarea')
-        .first();
+    const themeToggle = page.getByRole('button', { name: /switch to/i });
+    await expect(themeToggle).toBeVisible();
+    await themeToggle.click();
 
-      if ((await nameField.count()) > 0) {
-        await expect(nameField).toBeVisible();
-        await expect(nameField).toBeEnabled();
-      }
+    const expectedTheme = initialTheme === 'dark' ? 'light' : 'dark';
+    await expect(html).toHaveAttribute('data-theme', expectedTheme);
 
-      if ((await emailField.count()) > 0) {
-        await expect(emailField).toBeVisible();
-        await expect(emailField).toBeEnabled();
-      }
-
-      if ((await messageField.count()) > 0) {
-        await expect(messageField).toBeVisible();
-        await expect(messageField).toBeEnabled();
-      }
-    }
-  });
-
-  test('should have timeline/evolution section', async ({ page }) => {
-    const timelineSection = page.locator('#evolution, .timeline');
-
-    if (await timelineSection.isVisible()) {
-      // Should have timeline items
-      const timelineItems = timelineSection.locator('.timeline-item');
-      const itemCount = await timelineItems.count();
-
-      if (itemCount > 0) {
-        const firstItem = timelineItems.first();
-        await expect(firstItem).toBeVisible();
-
-        // Should have content structure
-        const itemContent = firstItem.locator('.timeline-content, h3, p');
-        await expect(itemContent.first()).toBeVisible();
-      }
-    }
-  });
-
-  test('should handle component interactions', async ({ page }) => {
-    const errors: string[] = [];
-    page.on('pageerror', (error) => {
-      errors.push(error.message);
-    });
-
-    // Test hero call-to-action interactions
-    const heroCtas = page.locator('.hero__cta');
-    if ((await heroCtas.count()) > 0) {
-      await heroCtas.first().click();
-      await page.waitForTimeout(500);
-    }
-
-    // Test any interactive cards
-    const interactiveCards = page.locator(
-      '.card[href], .card a, .project-card',
+    const storedTheme = await page.evaluate(() =>
+      localStorage.getItem('portfolio-theme'),
     );
-    const cardCount = await interactiveCards.count();
+    expect(storedTheme).toBe(expectedTheme);
 
-    if (cardCount > 0) {
-      const firstCard = interactiveCards.first();
-
-      // Hover should work without errors
-      await firstCard.hover();
-      await page.waitForTimeout(100);
-    }
-
-    expect(errors).toHaveLength(0);
+    await page.reload();
+    await expect(html).toHaveAttribute('data-theme', expectedTheme);
+    await expect(
+      page.getByRole('button', {
+        name: new RegExp(`Switch to ${initialTheme} mode`, 'i'),
+      }),
+    ).toBeVisible();
   });
 
-  test('should be accessible', async ({ page }) => {
-    // Check for proper heading structure
-    const h1 = page.locator('h1');
-    const h1Count = await h1.count();
-    expect(h1Count).toBeGreaterThanOrEqual(1);
-
-    // Check for proper landmark elements
-    const headers = page.locator('header');
-    const headerCount = await headers.count();
-    expect(headerCount).toBeGreaterThanOrEqual(1);
-
-    const mains = page.locator('main');
-    const mainCount = await mains.count();
-    expect(mainCount).toBeGreaterThanOrEqual(1);
-
-    // Check for alt text on images
-    const images = page.locator('img');
-    const imageCount = await images.count();
-
-    for (let i = 0; i < Math.min(imageCount, 5); i++) {
-      const img = images.nth(i);
-      if (await img.isVisible()) {
-        const alt = await img.getAttribute('alt');
-        expect(alt).toBeTruthy();
-        expect(alt?.length).toBeGreaterThan(0);
-      }
-    }
-
-    // Check for proper form labels
-    const inputs = page.locator('input, textarea, select');
-    const inputCount = await inputs.count();
-
-    for (let i = 0; i < Math.min(inputCount, 3); i++) {
-      const input = inputs.nth(i);
-      if (await input.isVisible()) {
-        const id = await input.getAttribute('id');
-        if (id) {
-          const label = page.locator(`label[for="${id}"]`);
-          await expect(label).toBeVisible();
-        }
-      }
-    }
-  });
-
-  test('should load without console errors', async ({ page }) => {
+  test('has no critical console errors', async ({ page }) => {
     const errors: string[] = [];
-    const warnings: string[] = [];
 
     page.on('pageerror', (error) => {
       errors.push(error.message);
@@ -197,15 +112,12 @@ test.describe('Component Integration Tests', () => {
     page.on('console', (msg) => {
       if (msg.type() === 'error') {
         errors.push(msg.text());
-      } else if (msg.type() === 'warning') {
-        warnings.push(msg.text());
       }
     });
 
     await page.goto('/');
     await page.waitForLoadState('networkidle');
 
-    // Should not have critical errors
     const criticalErrors = errors.filter(
       (error) =>
         !error.includes('favicon') &&
@@ -219,21 +131,10 @@ test.describe('Component Integration Tests', () => {
     expect(criticalErrors).toHaveLength(0);
   });
 
-  test('should be performant', async ({ page }) => {
-    // Navigate to page and wait for load
-    const startTime = Date.now();
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
-    const loadTime = Date.now() - startTime;
-
-    // Should load reasonably quickly (adjust threshold as needed)
-    expect(loadTime).toBeLessThan(10000); // 10 seconds max
-
-    // Check for layout shifts
-    await page.waitForTimeout(1000);
-
-    // Basic performance check - no major layout issues
-    const bodyHeight = await page.locator('body').boundingBox();
-    expect(bodyHeight?.height).toBeGreaterThan(100);
+  test('passes automated accessibility audit', async ({ page }) => {
+    const accessibilityScanResults = await new AxeBuilder({ page })
+      .disableRules('scrollable-region-focusable')
+      .analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- restructure the home page e2e spec to assert key sections, cover theme persistence, and run the axe accessibility audit helper
- add adaptive NGS case study e2e coverage for hero metrics, visualisations, and navigation from the home page

## Testing
- pnpm test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68cee67c9e5883338daafe9d1b65075d