### PR TITLE
fix: reveal sections faster on mobile

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -573,7 +573,12 @@ spec:
               }
             });
           },
-          { threshold: 0.1, rootMargin: '0px 0px -10% 0px' },
+          {
+            // Lower threshold prevents tall sections (like Projects) from
+            // staying invisible for too long on mobile before the reveal runs.
+            threshold: 0,
+            rootMargin: '0px 0px -6% 0px',
+          },
         );
 
         const revealIfVisible = (node: Element) => {


### PR DESCRIPTION
## Summary
- lower the reveal threshold so tall sections like Projects unhide quickly on mobile

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cf0967a6ec8333beaf9f01c866308e