### PR TITLE
fix: keep reveal scripts inline

### DIFF
--- a/src/layouts/CaseStudyLayout.astro
+++ b/src/layouts/CaseStudyLayout.astro
@@ -54,77 +54,10 @@ const {
       <slot />
     </div>
   </main>
-  <script>
-    const revealNodes = Array.from(document.querySelectorAll('[data-reveal]'));
+  <script type="module" is:inline>
+    import { initReveal } from '../scripts/initReveal';
 
-    if (revealNodes.length > 0) {
-      const rootElement = document.documentElement;
-      rootElement.removeAttribute('data-reveal-state');
-
-      const reduceMotionQuery =
-        'matchMedia' in window
-          ? window.matchMedia('(prefers-reduced-motion: reduce)')
-          : null;
-      const automationPattern =
-        /Headless|Playwright|Puppeteer|Chrome-Lighthouse|Speed\sInsights|Page Speed|Checkly|Screener|HeadlessShell/i;
-      const userAgent = navigator?.userAgent ?? '';
-      const isAutomationContext =
-        (typeof navigator !== 'undefined' && navigator.webdriver) ||
-        automationPattern.test(userAgent);
-
-      if (
-        reduceMotionQuery?.matches ||
-        !('IntersectionObserver' in window) ||
-        isAutomationContext
-      ) {
-        revealNodes.forEach((node) => {
-          node.classList.add('is-revealed', 'is-reveal-instant');
-        });
-      } else {
-        const observer = new IntersectionObserver(
-          (entries) => {
-            entries.forEach((entry) => {
-              if (entry.isIntersecting) {
-                entry.target.classList.add('is-revealed');
-                observer.unobserve(entry.target);
-              }
-            });
-          },
-          { threshold: 0.25, rootMargin: '0px 0px -10% 0px' },
-        );
-
-        const revealIfVisible = (node: Element) => {
-          const rect = node.getBoundingClientRect();
-          if (rect.bottom >= 0 && rect.top <= window.innerHeight) {
-            node.classList.add('is-revealed');
-            observer.unobserve(node);
-          }
-        };
-
-        revealNodes.forEach((node) => observer.observe(node));
-
-        const activateReveals = () => {
-          if (rootElement.dataset.revealState === 'active') {
-            return;
-          }
-
-          revealNodes.forEach(revealIfVisible);
-
-          requestAnimationFrame(() => {
-            rootElement.dataset.revealState = 'active';
-          });
-        };
-
-        if (window.scrollY > 0) {
-          activateReveals();
-        } else {
-          window.addEventListener('scroll', activateReveals, {
-            once: true,
-            passive: true,
-          });
-        }
-      }
-    }
+    initReveal({ threshold: 0.25, rootMargin: '-10%' });
   </script>
 </BaseLayout>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -537,82 +537,11 @@ spec:
     </section>
   </main>
 
-  <script>
-    const revealNodes = Array.from(document.querySelectorAll('[data-reveal]'));
+  <script type="module" is:inline>
+    import { initReveal } from '../scripts/initReveal';
 
-    if (revealNodes.length > 0) {
-      const rootElement = document.documentElement;
-      rootElement.removeAttribute('data-reveal-state');
-
-      const reduceMotionQuery =
-        'matchMedia' in window
-          ? window.matchMedia('(prefers-reduced-motion: reduce)')
-          : null;
-      const automationPattern =
-        /Headless|Playwright|Puppeteer|Chrome-Lighthouse|Speed\sInsights|Page Speed|Checkly|Screener|HeadlessShell/i;
-      const userAgent = navigator?.userAgent ?? '';
-      const isAutomationContext =
-        (typeof navigator !== 'undefined' && navigator.webdriver) ||
-        automationPattern.test(userAgent);
-
-      if (
-        reduceMotionQuery?.matches ||
-        !('IntersectionObserver' in window) ||
-        isAutomationContext
-      ) {
-        revealNodes.forEach((node) => {
-          node.classList.add('is-revealed', 'is-reveal-instant');
-        });
-      } else {
-        const observer = new IntersectionObserver(
-          (entries) => {
-            entries.forEach((entry) => {
-              if (entry.isIntersecting) {
-                entry.target.classList.add('is-revealed');
-                observer.unobserve(entry.target);
-              }
-            });
-          },
-          {
-            // Lower threshold prevents tall sections (like Projects) from
-            // staying invisible for too long on mobile before the reveal runs.
-            threshold: 0,
-            rootMargin: '0px 0px -6% 0px',
-          },
-        );
-
-        const revealIfVisible = (node: Element) => {
-          const rect = node.getBoundingClientRect();
-          if (rect.bottom >= 0 && rect.top <= window.innerHeight) {
-            node.classList.add('is-revealed');
-            observer.unobserve(node);
-          }
-        };
-
-        revealNodes.forEach((node) => observer.observe(node));
-
-        const activateReveals = () => {
-          if (rootElement.dataset.revealState === 'active') {
-            return;
-          }
-
-          revealNodes.forEach(revealIfVisible);
-
-          requestAnimationFrame(() => {
-            rootElement.dataset.revealState = 'active';
-          });
-        };
-
-        if (window.scrollY > 0) {
-          activateReveals();
-        } else {
-          window.addEventListener('scroll', activateReveals, {
-            once: true,
-            passive: true,
-          });
-        }
-      }
-    }
+    // Lower threshold prevents tall sections (like Projects) from remaining hidden too long on mobile.
+    initReveal({ threshold: 0, rootMargin: '-6%' });
   </script>
 </BaseLayout>
 

--- a/src/scripts/initReveal.ts
+++ b/src/scripts/initReveal.ts
@@ -1,0 +1,98 @@
+const automationPattern =
+  /Headless|Playwright|Puppeteer|Chrome-Lighthouse|Speed\sInsights|Page Speed|Checkly|Screener|HeadlessShell/i;
+
+type RevealOptions = {
+  threshold?: number;
+  rootMargin?: string;
+};
+
+const computeRootMargin = (margin?: string) => {
+  const value = (margin ?? '-8%').trim();
+  return value.includes(' ') ? value : `0px 0px ${value} 0px`;
+};
+
+export const initReveal = ({
+  threshold = 0,
+  rootMargin,
+}: RevealOptions = {}) => {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return;
+  }
+
+  const revealNodes = Array.from(document.querySelectorAll('[data-reveal]'));
+
+  if (revealNodes.length === 0) {
+    return;
+  }
+
+  const rootElement = document.documentElement;
+  rootElement.removeAttribute('data-reveal-state');
+
+  const reduceMotionQuery =
+    'matchMedia' in window
+      ? window.matchMedia('(prefers-reduced-motion: reduce)')
+      : null;
+
+  const userAgent =
+    typeof navigator !== 'undefined' ? (navigator.userAgent ?? '') : '';
+  const isAutomationContext =
+    (typeof navigator !== 'undefined' && navigator.webdriver) ||
+    automationPattern.test(userAgent);
+
+  if (
+    reduceMotionQuery?.matches ||
+    !('IntersectionObserver' in window) ||
+    isAutomationContext
+  ) {
+    revealNodes.forEach((node) => {
+      node.classList.add('is-revealed', 'is-reveal-instant');
+    });
+    return;
+  }
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('is-revealed');
+          observer.unobserve(entry.target);
+        }
+      });
+    },
+    {
+      threshold,
+      rootMargin: computeRootMargin(rootMargin),
+    },
+  );
+
+  const revealIfVisible = (node: Element) => {
+    const rect = node.getBoundingClientRect();
+    if (rect.bottom >= 0 && rect.top <= window.innerHeight) {
+      node.classList.add('is-revealed');
+      observer.unobserve(node);
+    }
+  };
+
+  revealNodes.forEach((node) => observer.observe(node));
+
+  const activateReveals = () => {
+    if (rootElement.dataset.revealState === 'active') {
+      return;
+    }
+
+    revealNodes.forEach(revealIfVisible);
+
+    requestAnimationFrame(() => {
+      rootElement.dataset.revealState = 'active';
+    });
+  };
+
+  if (window.scrollY > 0) {
+    activateReveals();
+  } else {
+    window.addEventListener('scroll', activateReveals, {
+      once: true,
+      passive: true,
+    });
+  }
+};


### PR DESCRIPTION
## Summary
- keep the home page reveal helper script inline by adding Astro's `is:inline` flag to the module tag
- do the same for the case study layout so both reuse the shared helper without generating extra bundles

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cf477110c483338b0dfef0beba4245