### PR TITLE
test: cover application skills interactions

### DIFF
--- a/tests/unit/components/skills/ApplicationSkills.spec.ts
+++ b/tests/unit/components/skills/ApplicationSkills.spec.ts
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+
+import ApplicationSkills from '../../../../src/components/skills/ApplicationSkills.svelte';
+
+describe('ApplicationSkills', () => {
+  it('shows the default category details and updates when selecting another category', async () => {
+    render(ApplicationSkills);
+
+    const scientificButton = screen.getByRole('button', {
+      name: /scientific computing/i,
+    });
+
+    expect(scientificButton).toHaveClass('selected');
+    expect(
+      screen.getByText(
+        /High-performance compute pipelines translating raw sequencer output into audit-ready biology/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Orchestrated RNA\/DNA-seq and variant calling through Nextflow Tower on AWS Batch/i,
+      ),
+    ).toBeInTheDocument();
+
+    const infrastructureButton = screen.getByRole('button', {
+      name: /infrastructure engineering/i,
+    });
+
+    await fireEvent.click(infrastructureButton);
+
+    expect(infrastructureButton).toHaveClass('selected');
+    expect(scientificButton).not.toHaveClass('selected');
+    expect(
+      screen.getByText(
+        /Hybrid cloud infrastructure connecting laboratory sequencers to computational pipelines/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Managed hybrid infrastructure spanning Azure Container Apps and on-premises Proxmox virtualization/i,
+      ),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test coverage for the ApplicationSkills component
- verify the default category details render and change on selection

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0323d600883338931119c86c90360