### PR TITLE
test: broaden svelte coverage and add component specs

### DIFF
--- a/tests/unit/components/infrastructure/PipelineOpsDashboard.spec.ts
+++ b/tests/unit/components/infrastructure/PipelineOpsDashboard.spec.ts
@@ -1,0 +1,50 @@
+import { cleanup, render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import PipelineOpsDashboard from '../../../../src/components/infrastructure/PipelineOpsDashboard.svelte';
+
+describe('PipelineOpsDashboard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0.75);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('updates metrics over time and clears its interval on destroy', async () => {
+    const intervalSpy = vi.spyOn(window, 'setInterval');
+    const clearSpy = vi.spyOn(window, 'clearInterval');
+    const { container } = render(PipelineOpsDashboard);
+
+    expect(intervalSpy).toHaveBeenCalledTimes(1);
+    expect(intervalSpy.mock.calls[0][1]).toBe(3200);
+
+    vi.advanceTimersByTime(3200);
+    await tick();
+
+    const metricItems = container.querySelectorAll<HTMLLIElement>(
+      '.dashboard__card--metrics li',
+    );
+    expect(metricItems[0].querySelector('strong')?.textContent).toContain(
+      '324',
+    );
+    expect(metricItems[1].querySelector('strong')?.textContent).toContain('21');
+    expect(metricItems[2].querySelector('strong')?.textContent).toContain(
+      '43.5',
+    );
+
+    const nodeValueSpans =
+      container.querySelectorAll<HTMLSpanElement>('.node__meter span');
+    expect(nodeValueSpans[0].textContent).toContain('99%');
+    expect(nodeValueSpans[1].textContent).toContain('95%');
+
+    const intervalId = intervalSpy.mock.results[0]?.value as number;
+    cleanup();
+
+    expect(clearSpy).toHaveBeenCalledWith(intervalId);
+  });
+});

--- a/tests/unit/components/infrastructure/PipelineOpsDashboard.spec.ts
+++ b/tests/unit/components/infrastructure/PipelineOpsDashboard.spec.ts
@@ -1,50 +1,104 @@
-import { cleanup, render } from '@testing-library/svelte';
+import { render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import PipelineOpsDashboard from '../../../../src/components/infrastructure/PipelineOpsDashboard.svelte';
 
+const METRICS_CONFIG = [
+  { label: 'Reads/hour', unit: 'M', baseline: 312, variance: 24 },
+  { label: 'Latency', unit: 'min', baseline: 18, variance: 6 },
+  { label: 'Cost / 10k samples', unit: '$', baseline: 42, variance: 3 },
+];
+
+const NODE_TARGETS = [
+  { id: 'ingest', target: 96 },
+  { id: 'qc', target: 92 },
+  { id: 'align', target: 80 },
+  { id: 'variant', target: 74 },
+];
+
+const INTERVAL_MS = 3200;
+const NODE_VARIANCE = 6;
+
 describe('PipelineOpsDashboard', () => {
-  beforeEach(() => {
+  it('applies deterministic jitter updates and clears intervals on unmount', async () => {
     vi.useFakeTimers();
-    vi.spyOn(Math, 'random').mockReturnValue(0.75);
-  });
 
-  afterEach(() => {
-    vi.useRealTimers();
-    vi.restoreAllMocks();
-  });
+    const randomSequence = [
+      0.6, 0.3, 0.8, 0.1, 0.7, 0.4, 0.9, 0.2, 0.55, 0.45, 0.65, 0.35, 0.75,
+      0.25, 0.85, 0.15,
+    ];
+    let callIndex = 0;
 
-  it('updates metrics over time and clears its interval on destroy', async () => {
-    const intervalSpy = vi.spyOn(window, 'setInterval');
-    const clearSpy = vi.spyOn(window, 'clearInterval');
-    const { container } = render(PipelineOpsDashboard);
+    const randomMock = vi.spyOn(Math, 'random').mockImplementation(() => {
+      const value = randomSequence[callIndex] ?? 0.5;
+      callIndex += 1;
+      return value;
+    });
 
-    expect(intervalSpy).toHaveBeenCalledTimes(1);
-    expect(intervalSpy.mock.calls[0][1]).toBe(3200);
+    try {
+      const { unmount } = render(PipelineOpsDashboard);
 
-    vi.advanceTimersByTime(3200);
-    await tick();
+      const metricsCard = screen.getByRole('heading', {
+        level: 4,
+        name: 'Throughput Envelope',
+      }).parentElement as HTMLElement;
+      const nodesCard = screen.getByRole('heading', {
+        level: 4,
+        name: 'Workflow reliability',
+      }).parentElement as HTMLElement;
 
-    const metricItems = container.querySelectorAll<HTMLLIElement>(
-      '.dashboard__card--metrics li',
-    );
-    expect(metricItems[0].querySelector('strong')?.textContent).toContain(
-      '324',
-    );
-    expect(metricItems[1].querySelector('strong')?.textContent).toContain('21');
-    expect(metricItems[2].querySelector('strong')?.textContent).toContain(
-      '43.5',
-    );
+      const readMetricValues = () =>
+        Array.from(metricsCard.querySelectorAll('strong')).map((element) =>
+          Number(element.childNodes[0]?.textContent?.trim()),
+        );
 
-    const nodeValueSpans =
-      container.querySelectorAll<HTMLSpanElement>('.node__meter span');
-    expect(nodeValueSpans[0].textContent).toContain('99%');
-    expect(nodeValueSpans[1].textContent).toContain('95%');
+      const readNodeValues = () =>
+        Array.from(nodesCard.querySelectorAll('.node__meter span')).map(
+          (element) => Number.parseInt(element.textContent ?? '', 10),
+        );
 
-    const intervalId = intervalSpy.mock.results[0]?.value as number;
-    cleanup();
+      const metricsBefore = readMetricValues();
+      const nodesBefore = readNodeValues();
 
-    expect(clearSpy).toHaveBeenCalledWith(intervalId);
+      expect(metricsBefore).toEqual(
+        METRICS_CONFIG.map((metric) => metric.baseline),
+      );
+      expect(nodesBefore).toEqual([92, 84, 71, 67]);
+
+      await vi.advanceTimersByTimeAsync(INTERVAL_MS);
+      await tick();
+
+      const metricsAfter = readMetricValues();
+      const nodesAfter = readNodeValues();
+
+      expect(metricsAfter).toEqual([316.8, 15.6, 43.8]);
+      expect(nodesAfter).toEqual([91, 94, 79, 79]);
+
+      metricsAfter.forEach((value, index) => {
+        const { baseline, variance } = METRICS_CONFIG[index];
+        expect(value).not.toBe(metricsBefore[index]);
+        expect(value).toBeGreaterThanOrEqual(baseline - variance);
+        expect(value).toBeLessThanOrEqual(baseline + variance);
+      });
+
+      nodesAfter.forEach((value, index) => {
+        const { target } = NODE_TARGETS[index];
+        expect(value).not.toBe(nodesBefore[index]);
+        expect(value).toBeGreaterThanOrEqual(target - NODE_VARIANCE);
+        expect(value).toBeLessThanOrEqual(target + NODE_VARIANCE);
+      });
+
+      expect(randomMock).toHaveBeenCalledTimes(8);
+
+      unmount();
+
+      await vi.advanceTimersByTimeAsync(INTERVAL_MS);
+
+      expect(randomMock).toHaveBeenCalledTimes(8);
+    } finally {
+      randomMock.mockRestore();
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/unit/components/skills/ApplicationSkills.spec.ts
+++ b/tests/unit/components/skills/ApplicationSkills.spec.ts
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+
+import ApplicationSkills from '../../../../src/components/skills/ApplicationSkills.svelte';
+
+describe('ApplicationSkills', () => {
+  it('shows the default category and switches details when selecting another', async () => {
+    render(ApplicationSkills);
+
+    const defaultButton = screen.getByRole('button', {
+      name: 'Scientific Computing',
+    });
+    expect(defaultButton).toHaveClass('selected');
+    expect(
+      screen.getByRole('heading', { level: 4, name: 'Scientific Computing' }),
+    ).toBeInTheDocument();
+
+    const infrastructureButton = screen.getByRole('button', {
+      name: 'Infrastructure Engineering',
+    });
+    expect(infrastructureButton).not.toHaveClass('selected');
+
+    await fireEvent.click(infrastructureButton);
+
+    expect(infrastructureButton).toHaveClass('selected');
+    expect(defaultButton).not.toHaveClass('selected');
+    expect(
+      screen.getByRole('heading', {
+        level: 4,
+        name: 'Infrastructure Engineering',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Managed hybrid infrastructure spanning Azure Container Apps and on-premises Proxmox virtualization',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Docker, GitHub Actions, Python automation, Bash scripting',
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/skills/ApplicationSkills.spec.ts
+++ b/tests/unit/components/skills/ApplicationSkills.spec.ts
@@ -4,40 +4,41 @@ import { describe, expect, it } from 'vitest';
 import ApplicationSkills from '../../../../src/components/skills/ApplicationSkills.svelte';
 
 describe('ApplicationSkills', () => {
-  it('shows the default category and switches details when selecting another', async () => {
+  it('shows the default category details and updates when selecting another category', async () => {
     render(ApplicationSkills);
 
-    const defaultButton = screen.getByRole('button', {
-      name: 'Scientific Computing',
+    const scientificButton = screen.getByRole('button', {
+      name: /scientific computing/i,
     });
-    expect(defaultButton).toHaveClass('selected');
-    expect(
-      screen.getByRole('heading', { level: 4, name: 'Scientific Computing' }),
-    ).toBeInTheDocument();
 
-    const infrastructureButton = screen.getByRole('button', {
-      name: 'Infrastructure Engineering',
-    });
-    expect(infrastructureButton).not.toHaveClass('selected');
-
-    await fireEvent.click(infrastructureButton);
-
-    expect(infrastructureButton).toHaveClass('selected');
-    expect(defaultButton).not.toHaveClass('selected');
-    expect(
-      screen.getByRole('heading', {
-        level: 4,
-        name: 'Infrastructure Engineering',
-      }),
-    ).toBeInTheDocument();
+    expect(scientificButton).toHaveClass('selected');
     expect(
       screen.getByText(
-        'Managed hybrid infrastructure spanning Azure Container Apps and on-premises Proxmox virtualization',
+        /High-performance compute pipelines translating raw sequencer output into audit-ready biology/i,
       ),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        'Docker, GitHub Actions, Python automation, Bash scripting',
+        /Orchestrated RNA\/DNA-seq and variant calling through Nextflow Tower on AWS Batch/i,
+      ),
+    ).toBeInTheDocument();
+
+    const infrastructureButton = screen.getByRole('button', {
+      name: /infrastructure engineering/i,
+    });
+
+    await fireEvent.click(infrastructureButton);
+
+    expect(infrastructureButton).toHaveClass('selected');
+    expect(scientificButton).not.toHaveClass('selected');
+    expect(
+      screen.getByText(
+        /Hybrid cloud infrastructure connecting laboratory sequencers to computational pipelines/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Managed hybrid infrastructure spanning Azure Container Apps and on-premises Proxmox virtualization/i,
       ),
     ).toBeInTheDocument();
   });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,11 +31,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],
-      include: [
-        'src/components/demos/**/*.svelte',
-        'src/components/ui/**/*.svelte',
-        'src/components/visualizations/**/*.svelte',
-      ],
+      include: ['src/components/**/*.svelte'],
       thresholds: {
         statements: 85,
         branches: 85,


### PR DESCRIPTION
## Summary
- expand the coverage include glob to exercise every Svelte component
- add focused specs for PipelineOpsDashboard and ApplicationSkills to keep thresholds green under the broader scope

## Testing
- pnpm test --coverage

------
https://chatgpt.com/codex/tasks/task_e_68d0323815d0833396b0b58bf50aa119