### PR TITLE
refactor: hoist sequence lookup maps

### DIFF
--- a/src/components/demos/SequenceWorkbench.svelte
+++ b/src/components/demos/SequenceWorkbench.svelte
@@ -1,6 +1,80 @@
 <script lang="ts">
   import { derived, writable } from 'svelte/store';
 
+  const COMPLEMENT_MAP = {
+    A: 'T',
+    T: 'A',
+    G: 'C',
+    C: 'G',
+  } as const;
+
+  const CODON_MAP = {
+    TTT: 'F',
+    TTC: 'F',
+    TTA: 'L',
+    TTG: 'L',
+    CTT: 'L',
+    CTC: 'L',
+    CTA: 'L',
+    CTG: 'L',
+    ATT: 'I',
+    ATC: 'I',
+    ATA: 'I',
+    ATG: 'M',
+    GTT: 'V',
+    GTC: 'V',
+    GTA: 'V',
+    GTG: 'V',
+    TCT: 'S',
+    TCC: 'S',
+    TCA: 'S',
+    TCG: 'S',
+    CCT: 'P',
+    CCC: 'P',
+    CCA: 'P',
+    CCG: 'P',
+    ACT: 'T',
+    ACC: 'T',
+    ACA: 'T',
+    ACG: 'T',
+    GCT: 'A',
+    GCC: 'A',
+    GCA: 'A',
+    GCG: 'A',
+    TAT: 'Y',
+    TAC: 'Y',
+    TAA: '*',
+    TAG: '*',
+    CAT: 'H',
+    CAC: 'H',
+    CAA: 'Q',
+    CAG: 'Q',
+    AAT: 'N',
+    AAC: 'N',
+    AAA: 'K',
+    AAG: 'K',
+    GAT: 'D',
+    GAC: 'D',
+    GAA: 'E',
+    GAG: 'E',
+    TGT: 'C',
+    TGC: 'C',
+    TGA: '*',
+    TGG: 'W',
+    CGT: 'R',
+    CGC: 'R',
+    CGA: 'R',
+    CGG: 'R',
+    AGT: 'S',
+    AGC: 'S',
+    AGA: 'R',
+    AGG: 'R',
+    GGT: 'G',
+    GGC: 'G',
+    GGA: 'G',
+    GGG: 'G',
+  } as const;
+
   const defaultSequence =
     'ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAGCTAGGACTAGCTAGGTCAGTCTGAGTGA';
 
@@ -16,90 +90,22 @@
     return Number(((gc / $sequence.length) * 100).toFixed(2));
   });
 
-  const reverseComplement = derived(cleanSequence, ($sequence) => {
-    const complement: Record<string, string> = { A: 'T', T: 'A', G: 'C', C: 'G' };
-    return $sequence
+  const reverseComplement = derived(cleanSequence, ($sequence) =>
+    $sequence
       .split('')
       .reverse()
-      .map((base) => complement[base])
-      .join('');
-  });
+      .map((base) => COMPLEMENT_MAP[base as keyof typeof COMPLEMENT_MAP])
+      .join('')
+  );
 
   const translate = (seq: string) => {
-    const codonMap: Record<string, string> = {
-      TTT: 'F',
-      TTC: 'F',
-      TTA: 'L',
-      TTG: 'L',
-      CTT: 'L',
-      CTC: 'L',
-      CTA: 'L',
-      CTG: 'L',
-      ATT: 'I',
-      ATC: 'I',
-      ATA: 'I',
-      ATG: 'M',
-      GTT: 'V',
-      GTC: 'V',
-      GTA: 'V',
-      GTG: 'V',
-      TCT: 'S',
-      TCC: 'S',
-      TCA: 'S',
-      TCG: 'S',
-      CCT: 'P',
-      CCC: 'P',
-      CCA: 'P',
-      CCG: 'P',
-      ACT: 'T',
-      ACC: 'T',
-      ACA: 'T',
-      ACG: 'T',
-      GCT: 'A',
-      GCC: 'A',
-      GCA: 'A',
-      GCG: 'A',
-      TAT: 'Y',
-      TAC: 'Y',
-      TAA: '*',
-      TAG: '*',
-      CAT: 'H',
-      CAC: 'H',
-      CAA: 'Q',
-      CAG: 'Q',
-      AAT: 'N',
-      AAC: 'N',
-      AAA: 'K',
-      AAG: 'K',
-      GAT: 'D',
-      GAC: 'D',
-      GAA: 'E',
-      GAG: 'E',
-      TGT: 'C',
-      TGC: 'C',
-      TGA: '*',
-      TGG: 'W',
-      CGT: 'R',
-      CGC: 'R',
-      CGA: 'R',
-      CGG: 'R',
-      AGT: 'S',
-      AGC: 'S',
-      AGA: 'R',
-      AGG: 'R',
-      GGT: 'G',
-      GGC: 'G',
-      GGA: 'G',
-      GGG: 'G',
-    };
-
     const peptides: string[] = [];
     for (let frame = 0; frame < 3; frame += 1) {
       let peptide = '';
       for (let i = frame; i < seq.length; i += 3) {
         const codon = seq.slice(i, i + 3);
         if (codon.length < 3) break;
-        peptide += codonMap[codon] ?? '?';
+        peptide += CODON_MAP[codon as keyof typeof CODON_MAP] ?? '?';
       }
       peptides.push(peptide);
     }


### PR DESCRIPTION
## Summary
- hoist the reverse-complement and codon lookup tables into module scope constants
- reuse the shared constants in the reverse complement store and translation helper

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d04a280b5c83339972159b549bbf3c