### PR TITLE
refactor: extract reusable project card component

### DIFF
--- a/src/components/home/ProjectCard.astro
+++ b/src/components/home/ProjectCard.astro
@@ -1,0 +1,142 @@
+---
+import type { Project } from '../../content/home';
+
+interface Props {
+  project: Project;
+}
+
+const { project } = Astro.props as Props;
+---
+
+{
+  (() => {
+    switch (project.layout) {
+      case 'wide':
+        return (
+          <article class="project-card project-card--wide u-glass" data-reveal>
+            <header>
+              <h3>{project.title}</h3>
+              <p>{project.summary}</p>
+            </header>
+            <div class="project-card__content">
+              <div>
+                <h4>Problem</h4>
+                <p>{project.problem}</p>
+              </div>
+              <div>
+                <h4>Solution</h4>
+                <p>{project.solution}</p>
+              </div>
+              <div>
+                <h4>Stack</h4>
+                <ul class="project-card__tags">
+                  {project.stack.map((item) => (
+                    <li>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+            <div class="project-card__footer">
+              <div>
+                <h4>Results</h4>
+                <ul>
+                  {project.results.map((result) => (
+                    <li>{result}</li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <h4>Technical Challenges</h4>
+                <ul>
+                  {project.challenges.map((item) => (
+                    <li>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+            {project.link && (
+              <a class="project-card__link" href={project.link}>
+                Read research-style case study →
+              </a>
+            )}
+          </article>
+        );
+      case 'standard':
+        return (
+          <article class="project-card project-card--standard" data-reveal>
+            <header>
+              <h3>{project.title}</h3>
+              <p>{project.summary}</p>
+            </header>
+            <dl>
+              <div>
+                <dt>Problem</dt>
+                <dd>{project.problem}</dd>
+              </div>
+              <div>
+                <dt>Solution</dt>
+                <dd>{project.solution}</dd>
+              </div>
+            </dl>
+            <div class="project-card__meta">
+              <h4>Stack</h4>
+              <ul class="project-card__tags">
+                {project.stack.map((item) => (
+                  <li>{item}</li>
+                ))}
+              </ul>
+              <h4>Results</h4>
+              <ul>
+                {project.results.map((item) => (
+                  <li>{item}</li>
+                ))}
+              </ul>
+              <h4>Technical Challenges</h4>
+              <ul>
+                {project.challenges.map((item) => (
+                  <li>{item}</li>
+                ))}
+              </ul>
+            </div>
+          </article>
+        );
+      case 'tall':
+        return (
+          <article class="project-card project-card--tall" data-reveal>
+            <header>
+              <h3>{project.title}</h3>
+              <p>{project.summary}</p>
+            </header>
+            <div class="project-card__meta">
+              <h4>Problem</h4>
+              <p>{project.problem}</p>
+              <h4>Solution</h4>
+              <p>{project.solution}</p>
+            </div>
+            <div class="project-card__meta">
+              <h4>Stack</h4>
+              <ul class="project-card__tags">
+                {project.stack.map((item) => (
+                  <li>{item}</li>
+                ))}
+              </ul>
+              <h4>Results</h4>
+              <ul>
+                {project.results.map((item) => (
+                  <li>{item}</li>
+                ))}
+              </ul>
+              <h4>Technical Challenges</h4>
+              <ul>
+                {project.challenges.map((item) => (
+                  <li>{item}</li>
+                ))}
+              </ul>
+            </div>
+          </article>
+        );
+      default:
+        return null;
+    }
+  })()
+}

--- a/src/components/home/ProjectsSection.astro
+++ b/src/components/home/ProjectsSection.astro
@@ -1,4 +1,5 @@
 ---
+import ProjectCard from './ProjectCard.astro';
 import Ic50Visualizer from '../visualizations/Ic50Visualizer.svelte';
 import PipelineOpsDashboard from '../infrastructure/PipelineOpsDashboard.svelte';
 import type { Project } from '../../content/home';
@@ -24,146 +25,23 @@ const { projects } = Astro.props as Props;
   </div>
 
   <div class="u-container projects__grid">
-    <article class="project-card project-card--wide u-glass" data-reveal>
-      <header>
-        <h3>{projects[0].title}</h3>
-        <p>{projects[0].summary}</p>
-      </header>
-      <div class="project-card__content">
-        <div>
-          <h4>Problem</h4>
-          <p>{projects[0].problem}</p>
-        </div>
-        <div>
-          <h4>Solution</h4>
-          <p>{projects[0].solution}</p>
-        </div>
-        <div>
-          <h4>Stack</h4>
-          <ul class="project-card__tags">
-            {projects[0].stack.map((item) => <li>{item}</li>)}
-          </ul>
-        </div>
-      </div>
-      <div class="project-card__footer">
-        <div>
-          <h4>Results</h4>
-          <ul>
-            {projects[0].results.map((result) => <li>{result}</li>)}
-          </ul>
-        </div>
-        <div>
-          <h4>Technical Challenges</h4>
-          <ul>
-            {projects[0].challenges.map((item) => <li>{item}</li>)}
-          </ul>
-        </div>
-      </div>
-      {
-        projects[0].link && (
-          <a class="project-card__link" href={projects[0].link}>
-            Read research-style case study →
-          </a>
-        )
-      }
-    </article>
-
-    <article class="project-card project-card--standard" data-reveal>
-      <header>
-        <h3>{projects[1].title}</h3>
-        <p>{projects[1].summary}</p>
-      </header>
-      <dl>
-        <div>
-          <dt>Problem</dt>
-          <dd>{projects[1].problem}</dd>
-        </div>
-        <div>
-          <dt>Solution</dt>
-          <dd>{projects[1].solution}</dd>
-        </div>
-      </dl>
-      <div class="project-card__meta">
-        <h4>Stack</h4>
-        <ul class="project-card__tags">
-          {projects[1].stack.map((item) => <li>{item}</li>)}
-        </ul>
-        <h4>Results</h4>
-        <ul>
-          {projects[1].results.map((item) => <li>{item}</li>)}
-        </ul>
-        <h4>Technical Challenges</h4>
-        <ul>
-          {projects[1].challenges.map((item) => <li>{item}</li>)}
-        </ul>
-      </div>
-    </article>
-
-    <div class="project-card project-card--viz" data-reveal>
-      <Ic50Visualizer client:visible />
-    </div>
-
-    <article class="project-card project-card--tall" data-reveal>
-      <header>
-        <h3>{projects[2].title}</h3>
-        <p>{projects[2].summary}</p>
-      </header>
-      <div class="project-card__meta">
-        <h4>Problem</h4>
-        <p>{projects[2].problem}</p>
-        <h4>Solution</h4>
-        <p>{projects[2].solution}</p>
-      </div>
-      <div class="project-card__meta">
-        <h4>Stack</h4>
-        <ul class="project-card__tags">
-          {projects[2].stack.map((item) => <li>{item}</li>)}
-        </ul>
-        <h4>Results</h4>
-        <ul>
-          {projects[2].results.map((item) => <li>{item}</li>)}
-        </ul>
-        <h4>Technical Challenges</h4>
-        <ul>
-          {projects[2].challenges.map((item) => <li>{item}</li>)}
-        </ul>
-      </div>
-    </article>
-
-    <article class="project-card project-card--standard" data-reveal>
-      <header>
-        <h3>{projects[3].title}</h3>
-        <p>{projects[3].summary}</p>
-      </header>
-      <dl>
-        <div>
-          <dt>Problem</dt>
-          <dd>{projects[3].problem}</dd>
-        </div>
-        <div>
-          <dt>Solution</dt>
-          <dd>{projects[3].solution}</dd>
-        </div>
-      </dl>
-      <div class="project-card__meta">
-        <h4>Stack</h4>
-        <ul class="project-card__tags">
-          {projects[3].stack.map((item) => <li>{item}</li>)}
-        </ul>
-        <h4>Results</h4>
-        <ul>
-          {projects[3].results.map((item) => <li>{item}</li>)}
-        </ul>
-        <h4>Technical Challenges</h4>
-        <ul>
-          {projects[3].challenges.map((item) => <li>{item}</li>)}
-        </ul>
-      </div>
-    </article>
-
-    <div class="project-card project-card--dashboard" data-reveal>
-      <PipelineOpsDashboard client:visible />
-    </div>
+    {
+      projects.map((project, index) => (
+        <>
+          <ProjectCard project={project} />
+          {index === 1 && (
+            <div class="project-card project-card--viz" data-reveal>
+              <Ic50Visualizer client:visible />
+            </div>
+          )}
+          {index === projects.length - 1 && (
+            <div class="project-card project-card--dashboard" data-reveal>
+              <PipelineOpsDashboard client:visible />
+            </div>
+          )}
+        </>
+      ))
+    }
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- extract repeated project card markup into a dedicated `ProjectCard` helper that switches on each project's layout
- render featured projects via a single `projects.map` iteration and interleave the Ic50 visualizer and PipelineOps dashboard without duplicating markup

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d04a305d3c83339d02df77732dac10