### PR TITLE
fix: widen layout container for large screens

### DIFF
--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -20,7 +20,7 @@
     --text-sm: 0.875rem;
 
     /* Sizing & spacing */
-    --size-max-width: 1240px;
+    --size-max-width: clamp(1240px, 92vw, 2400px);
     --size-readable: 68ch;
     --space-2xs: 0.375rem;
     --space-xs: 0.625rem;


### PR DESCRIPTION
## Summary
- allow the shared container width token to grow with the viewport on large displays so hero and section content use more horizontal space

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d04d5907bc83339ba1931e142c9bee