### PR TITLE
chore(release): include style commits in patch releases

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -2,7 +2,13 @@ export default {
   branches: ["main"],
   repositoryUrl: "https://github.com/yamshy/portfolio",
   plugins: [
-    ["@semantic-release/commit-analyzer", { preset: "conventionalcommits" }],
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        preset: "conventionalcommits",
+        releaseRules: [{ type: "style", release: "patch" }]
+      }
+    ],
     ["@semantic-release/release-notes-generator", { preset: "conventionalcommits" }],
     ["@semantic-release/changelog", { changelogFile: "CHANGELOG.md", changelogTitle: "# Changelog" }],
     ["@semantic-release/npm", { npmPublish: false }],


### PR DESCRIPTION
## Summary
- ensure semantic-release treats `style` commits as patch releases so they trigger the usual automation

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d05a5fe7548333aa3db6e9f1db91b1