### PR TITLE
refactor: consolidate surface card styling

### DIFF
--- a/src/components/demos/SequenceWorkbench.svelte
+++ b/src/components/demos/SequenceWorkbench.svelte
@@ -115,7 +115,7 @@
   const peptides = derived(cleanSequence, translate);
 </script>
 
-<section class="workbench" aria-label="Sequence analysis tool">
+<section class="workbench u-surface-card" aria-label="Sequence analysis tool">
   <header>
     <p class="u-title-overline">Live Demo</p>
     <h3>Sequence Workbench</h3>
@@ -136,7 +136,7 @@
       ></textarea>
     </label>
 
-    <div class="workbench__panel">
+    <div class="workbench__panel u-surface-card">
       <div>
         <h4>GC Content</h4>
         <p><strong>{$gcContent}%</strong> GC across {$cleanSequence.length} bp</p>
@@ -166,13 +166,18 @@
 
 <style>
   .workbench {
+    --surface-card-background: color-mix(
+      in oklab,
+      var(--color-surface) 92%,
+      transparent 8%
+    );
+    --surface-card-border-color: color-mix(
+      in oklab,
+      var(--color-border) 60%,
+      transparent 40%
+    );
     display: grid;
     gap: var(--space-lg);
-    padding: var(--space-lg);
-    background: color-mix(in oklab, var(--color-surface) 92%, transparent 8%);
-    border-radius: var(--radius-lg);
-    border: 1px solid color-mix(in oklab, var(--color-border) 60%, transparent 40%);
-    box-shadow: var(--shadow-sm);
   }
 
   header h3 {
@@ -218,13 +223,20 @@
   }
 
   .workbench__panel {
+    --surface-card-padding: var(--space-md);
+    --surface-card-radius: var(--radius-md);
+    --surface-card-background: color-mix(
+      in oklab,
+      var(--color-surface-strong) 45%,
+      var(--color-surface) 55%
+    );
+    --surface-card-border-color: color-mix(
+      in oklab,
+      var(--color-border) 60%,
+      transparent 40%
+    );
     display: grid;
     gap: var(--space-md);
-    padding: var(--space-md);
-    background: color-mix(in oklab, var(--color-surface-strong) 45%, var(--color-surface) 55%);
-    border-radius: var(--radius-md);
-    border: 1px solid color-mix(in oklab, var(--color-border) 60%, transparent 40%);
-    box-shadow: var(--shadow-sm);
   }
 
   .workbench__panel code {
@@ -316,7 +328,7 @@
 
   @media (max-width: 600px) {
     .workbench {
-      padding: var(--space-md);
+      --surface-card-padding: var(--space-md);
     }
   }
 </style>

--- a/src/components/home/ExperienceSection.astro
+++ b/src/components/home/ExperienceSection.astro
@@ -25,7 +25,7 @@ const { experiences } = Astro.props as Props;
   <div class="u-container experience">
     {
       experiences.map((job) => (
-        <article class="experience__item">
+        <article class="experience__item u-surface-card">
           <header>
             <h3>{job.role}</h3>
             <p>{job.org}</p>
@@ -50,15 +50,17 @@ const { experiences } = Astro.props as Props;
   }
 
   .experience__item {
-    padding: var(--space-lg);
-    border-radius: var(--radius-lg);
-    border: 1px solid
-      color-mix(in oklab, var(--color-border) 60%, transparent 40%);
-    background: color-mix(
+    --surface-card-border-color: color-mix(
+      in oklab,
+      var(--color-border) 60%,
+      transparent 40%
+    );
+    --surface-card-background: color-mix(
       in oklab,
       var(--color-surface-strong) 35%,
       var(--color-surface) 65%
     );
+    --surface-card-shadow: none;
     display: grid;
     gap: var(--space-sm);
   }

--- a/src/components/home/InsightsSection.astro
+++ b/src/components/home/InsightsSection.astro
@@ -24,18 +24,18 @@ const { insights, codeSample } = Astro.props as Props;
   <div class="u-container insights__grid">
     {
       insights.map((insight) => (
-        <article class="insight-card">
+        <article class="insight-card u-surface-card">
           <h3>{insight.title}</h3>
           <p>{insight.summary}</p>
         </article>
       ))
     }
-    <article class="insight-card insight-card--code">
+    <article class="insight-card insight-card--code u-surface-card">
       <h3>Automation blueprint</h3>
       <p>Workflow manifest powering adaptive sequencing orchestration.</p>
       <pre><code>{codeSample}</code></pre>
     </article>
-    <article class="insight-card insight-card--demo" data-reveal>
+    <article class="insight-card insight-card--demo u-surface-card" data-reveal>
       <SequenceWorkbench client:visible />
     </article>
   </div>
@@ -56,11 +56,17 @@ const { insights, codeSample } = Astro.props as Props;
   }
 
   .insight-card {
-    padding: var(--space-lg);
-    border-radius: var(--radius-lg);
-    border: 1px solid
-      color-mix(in oklab, var(--color-border) 50%, transparent 50%);
-    background: color-mix(in oklab, var(--color-surface) 85%, transparent 15%);
+    --surface-card-border-color: color-mix(
+      in oklab,
+      var(--color-border) 50%,
+      transparent 50%
+    );
+    --surface-card-background: color-mix(
+      in oklab,
+      var(--color-surface) 85%,
+      transparent 15%
+    );
+    --surface-card-shadow: none;
     display: grid;
     gap: var(--space-sm);
   }
@@ -84,9 +90,11 @@ const { insights, codeSample } = Astro.props as Props;
   }
 
   .insight-card--demo {
-    padding: 0;
+    --surface-card-padding: 0;
+    --surface-card-border-color: transparent;
+    --surface-card-background: none;
+    --surface-card-shadow: none;
     border: none;
-    background: none;
   }
 
   @media (min-width: 960px) {

--- a/src/components/home/ProjectCard.astro
+++ b/src/components/home/ProjectCard.astro
@@ -13,7 +13,10 @@ const { project } = Astro.props as Props;
     switch (project.layout) {
       case 'wide':
         return (
-          <article class="project-card project-card--wide u-glass" data-reveal>
+          <article
+            class="project-card project-card--wide u-surface-card u-glass"
+            data-reveal
+          >
             <header>
               <h3>{project.title}</h3>
               <p>{project.summary}</p>
@@ -63,7 +66,10 @@ const { project } = Astro.props as Props;
         );
       case 'standard':
         return (
-          <article class="project-card project-card--standard" data-reveal>
+          <article
+            class="project-card project-card--standard u-surface-card"
+            data-reveal
+          >
             <header>
               <h3>{project.title}</h3>
               <p>{project.summary}</p>
@@ -102,7 +108,10 @@ const { project } = Astro.props as Props;
         );
       case 'tall':
         return (
-          <article class="project-card project-card--tall" data-reveal>
+          <article
+            class="project-card project-card--tall u-surface-card"
+            data-reveal
+          >
             <header>
               <h3>{project.title}</h3>
               <p>{project.summary}</p>

--- a/src/components/home/ProjectsSection.astro
+++ b/src/components/home/ProjectsSection.astro
@@ -53,12 +53,6 @@ const { projects } = Astro.props as Props;
 
   .project-card {
     position: relative;
-    padding: var(--space-lg);
-    border-radius: var(--radius-lg);
-    border: 1px solid
-      color-mix(in oklab, var(--color-border) 55%, transparent 45%);
-    background: color-mix(in oklab, var(--color-surface) 88%, transparent 12%);
-    box-shadow: var(--shadow-sm);
     display: grid;
     gap: var(--space-md);
   }
@@ -157,7 +151,7 @@ const { projects } = Astro.props as Props;
 
   @media (max-width: 720px) {
     .project-card {
-      padding: var(--space-md);
+      --surface-card-padding: var(--space-md);
     }
   }
 </style>

--- a/src/pages/case-studies/adaptive-ngs.astro
+++ b/src/pages/case-studies/adaptive-ngs.astro
@@ -74,7 +74,7 @@ const riskMitigations = [
   <section class="section" id="methods" data-reveal>
     <h2>Methods</h2>
     <div class="two-column">
-      <article>
+      <article class="u-surface-card">
         <h3>Workflow architecture</h3>
         <p>
           Sequencing stages were decomposed into <span class="u-code-inline"
@@ -101,7 +101,7 @@ const riskMitigations = [
           </li>
         </ul>
       </article>
-      <article>
+      <article class="u-surface-card">
         <h3>Validation protocol</h3>
         <p>
           Every DAG change shipped through a controlled validation harness.
@@ -122,10 +122,14 @@ const riskMitigations = [
     </div>
   </section>
 
-  <section class="section section--results" id="results" data-reveal>
+  <section
+    class="section section--results u-surface-card"
+    id="results"
+    data-reveal
+  >
     <h2>Results</h2>
     <div class="results-grid">
-      <article>
+      <article class="u-surface-card">
         <h3>Performance uplift</h3>
         <table>
           <thead>
@@ -158,7 +162,7 @@ const riskMitigations = [
           </tbody>
         </table>
       </article>
-      <article>
+      <article class="u-surface-card">
         <h3>Scientific fidelity</h3>
         <p>
           Adaptive QC prevented reagent drift from corrupting downstream
@@ -166,11 +170,11 @@ const riskMitigations = [
           platform surfaced potency shifts early enough for biologists to
           intervene.
         </p>
-        <div class="results-grid__viz">
+        <div class="results-grid__viz u-surface-card">
           <Ic50Visualizer client:visible />
         </div>
       </article>
-      <article>
+      <article class="u-surface-card">
         <h3>Regulatory operations</h3>
         <ul>
           <li>
@@ -193,7 +197,7 @@ const riskMitigations = [
       to scientists—not just platform teams. Weekly operations reviews pair this
       dashboard with reagent QC data to prioritise optimisation work.
     </p>
-    <div class="operations">
+    <div class="operations u-surface-card">
       <PipelineOpsDashboard client:visible />
     </div>
   </section>
@@ -203,7 +207,7 @@ const riskMitigations = [
     <div class="mitigations">
       {
         riskMitigations.map((item) => (
-          <article>
+          <article class="u-surface-card">
             <h3>{item.label}</h3>
             <p>{item.detail}</p>
           </article>
@@ -259,15 +263,19 @@ const riskMitigations = [
   }
 
   .two-column article {
-    padding: var(--space-md);
-    border-radius: var(--radius-md);
-    border: 1px solid
-      color-mix(in oklab, var(--color-border) 55%, transparent 45%);
-    background: color-mix(
+    --surface-card-padding: var(--space-md);
+    --surface-card-radius: var(--radius-md);
+    --surface-card-border-color: color-mix(
+      in oklab,
+      var(--color-border) 55%,
+      transparent 45%
+    );
+    --surface-card-background: color-mix(
       in oklab,
       var(--color-surface-strong) 35%,
       var(--color-surface) 65%
     );
+    --surface-card-shadow: none;
     display: grid;
     gap: var(--space-sm);
   }
@@ -279,15 +287,18 @@ const riskMitigations = [
   }
 
   .section--results {
-    background: color-mix(
+    --surface-card-background: color-mix(
       in oklab,
       var(--color-surface-muted) 20%,
       var(--color-surface) 80%
     );
-    padding: var(--space-xl);
-    border-radius: var(--radius-lg);
-    border: 1px solid
-      color-mix(in oklab, var(--color-border) 55%, transparent 45%);
+    --surface-card-padding: var(--space-xl);
+    --surface-card-border-color: color-mix(
+      in oklab,
+      var(--color-border) 55%,
+      transparent 45%
+    );
+    --surface-card-shadow: none;
   }
 
   .results-grid {
@@ -296,11 +307,19 @@ const riskMitigations = [
   }
 
   .results-grid article {
-    background: color-mix(in oklab, var(--color-surface) 85%, transparent 15%);
-    border-radius: var(--radius-md);
-    padding: var(--space-md);
-    border: 1px solid
-      color-mix(in oklab, var(--color-border) 55%, transparent 45%);
+    --surface-card-background: color-mix(
+      in oklab,
+      var(--color-surface) 85%,
+      transparent 15%
+    );
+    --surface-card-radius: var(--radius-md);
+    --surface-card-padding: var(--space-md);
+    --surface-card-border-color: color-mix(
+      in oklab,
+      var(--color-border) 55%,
+      transparent 45%
+    );
+    --surface-card-shadow: none;
     display: grid;
     gap: var(--space-sm);
   }
@@ -327,21 +346,36 @@ const riskMitigations = [
   }
 
   .results-grid__viz {
-    padding: var(--space-md);
-    background: color-mix(in oklab, var(--color-surface) 90%, transparent 10%);
-    border-radius: var(--radius-md);
-    border: 1px solid
-      color-mix(in oklab, var(--color-border) 55%, transparent 45%);
+    --surface-card-padding: var(--space-md);
+    --surface-card-radius: var(--radius-md);
+    --surface-card-background: color-mix(
+      in oklab,
+      var(--color-surface) 90%,
+      transparent 10%
+    );
+    --surface-card-border-color: color-mix(
+      in oklab,
+      var(--color-border) 55%,
+      transparent 45%
+    );
+    --surface-card-shadow: none;
   }
 
   .operations {
     margin-top: var(--space-md);
-    border-radius: var(--radius-lg);
     overflow: hidden;
-    border: 1px solid
-      color-mix(in oklab, var(--color-border) 55%, transparent 45%);
-    background: color-mix(in oklab, var(--color-surface) 90%, transparent 10%);
-    padding: var(--space-md);
+    --surface-card-padding: var(--space-md);
+    --surface-card-background: color-mix(
+      in oklab,
+      var(--color-surface) 90%,
+      transparent 10%
+    );
+    --surface-card-border-color: color-mix(
+      in oklab,
+      var(--color-border) 55%,
+      transparent 45%
+    );
+    --surface-card-shadow: none;
   }
 
   .mitigations {
@@ -350,15 +384,19 @@ const riskMitigations = [
   }
 
   .mitigations article {
-    padding: var(--space-md);
-    border-radius: var(--radius-md);
-    border: 1px solid
-      color-mix(in oklab, var(--color-border) 55%, transparent 45%);
-    background: color-mix(
+    --surface-card-padding: var(--space-md);
+    --surface-card-radius: var(--radius-md);
+    --surface-card-border-color: color-mix(
+      in oklab,
+      var(--color-border) 55%,
+      transparent 45%
+    );
+    --surface-card-background: color-mix(
       in oklab,
       var(--color-surface-strong) 35%,
       var(--color-surface) 65%
     );
+    --surface-card-shadow: none;
   }
 
   .phases {
@@ -370,11 +408,19 @@ const riskMitigations = [
   }
 
   .phases li {
-    padding: var(--space-md);
-    border-radius: var(--radius-md);
-    border: 1px solid
-      color-mix(in oklab, var(--color-border) 55%, transparent 45%);
-    background: color-mix(in oklab, var(--color-surface) 85%, transparent 15%);
+    --surface-card-padding: var(--space-md);
+    --surface-card-radius: var(--radius-md);
+    --surface-card-border-color: color-mix(
+      in oklab,
+      var(--color-border) 55%,
+      transparent 45%
+    );
+    --surface-card-background: color-mix(
+      in oklab,
+      var(--color-surface) 85%,
+      transparent 15%
+    );
+    --surface-card-shadow: none;
     display: grid;
     gap: 0.5rem;
   }

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -15,6 +15,28 @@
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   }
 
+  .u-surface-card {
+    --surface-card-padding: var(--space-lg);
+    --surface-card-radius: var(--radius-lg);
+    --surface-card-border-color: color-mix(
+      in oklab,
+      var(--color-border) 55%,
+      transparent 45%
+    );
+    --surface-card-background: color-mix(
+      in oklab,
+      var(--color-surface) 88%,
+      transparent 12%
+    );
+    --surface-card-shadow: var(--shadow-sm);
+
+    padding: var(--surface-card-padding);
+    border-radius: var(--surface-card-radius);
+    border: 1px solid var(--surface-card-border-color);
+    background: var(--surface-card-background);
+    box-shadow: var(--surface-card-shadow);
+  }
+
   .u-glass {
     background: color-mix(in oklab, var(--color-surface) 88%, transparent 12%);
     border: 1px solid


### PR DESCRIPTION
## Summary
- add a reusable `.u-surface-card` utility to centralize card surface styles with overridable CSS variables
- refactor home sections, SequenceWorkbench, and the adaptive NGS case study to consume the utility while keeping their layout tweaks

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d05953f4a08333af5a604f5a10378d