### PR TITLE
fix: refine hero positioning copy

### DIFF
--- a/src/components/home/HeroSection.astro
+++ b/src/components/home/HeroSection.astro
@@ -13,18 +13,17 @@ const { stats } = Astro.props as Props;
     <div class="hero__copy">
       <p class="hero__name">Shyam Ajudia</p>
       <h1 class="hero__title">
-        From lab bench rigor
-        <span class="hero__title--accent">to production-grade reliability</span>
+        From lab bench
+        <span class="hero__title--accent"
+          >to production-grade genomic platforms</span
+        >
       </h1>
       <p class="hero__lede">
-        I moved from sequencing experiments to engineering the DevOps backbones
-        that keep them running. I design CI/CD pipelines, containerized
-        deployments, and infrastructure automation that preserve the
-        reproducibility I demanded at the bench while delivering the reliability
-        leaders expect in production. Recent work implementing GitHub Actions
-        workflows, managing Azure Container Apps, and developing Python
-        automation that cut processing time by 50% shows how I migrate
-        scientific teams onto scalable, observable cloud platforms.
+        I translate wet-lab science into production-ready genomic platforms.
+        Building resilient infrastructure for life sciences with deep biological
+        context, I've spent 5+ years automating NGS pipelines, managing research
+        systems, and cutting genomic processing time by 50%. Today I run
+        GitOps-driven Kubernetes workloads tailored to scientific teams.
       </p>
       <div class="hero__actions">
         <a class="hero__cta" href="#contact">Collaborate</a>


### PR DESCRIPTION
## Summary
- fine-tune the hero heading to read "From lab bench" while keeping the existing platform emphasis
- update the hero description to remove the specific company reference and maintain biotech infrastructure positioning

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d071ff6c0883338f65f7dca9b07481