### PR TITLE
style: adjust layout spacing for wide screens

### DIFF
--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -20,7 +20,7 @@
     --text-sm: 0.875rem;
 
     /* Sizing & spacing */
-    --size-max-width: clamp(1240px, 92vw, 2400px);
+    --size-max-width: clamp(1240px, 88vw, 2100px);
     --size-readable: 68ch;
     --space-2xs: 0.375rem;
     --space-xs: 0.625rem;

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -2,7 +2,7 @@
   .u-container {
     width: min(100%, var(--size-max-width));
     margin-inline: auto;
-    padding-inline: clamp(var(--space-md), 5vw, var(--space-xl));
+    padding-inline: clamp(var(--space-md), 6vw, var(--space-3xl));
   }
 
   .u-stack > * + * {


### PR DESCRIPTION
## Summary
- reduce the global max layout width to 2100px with an 88vw preference so the page stays narrower on very large displays
- expand the shared container's padding clamp so horizontal gutters grow on wide screens

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d07ba657048333b978a587faee35b1