### PR TITLE
fix: resolve astro check hints

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import jsxA11y from 'eslint-plugin-jsx-a11y';
 import globals from 'globals';
 import prettier from 'eslint-config-prettier';
 
-export default tseslint.config(
+export default [
   {
     ignores: [
       'dist',
@@ -51,4 +51,4 @@ export default tseslint.config(
       },
     },
   },
-);
+];

--- a/src/components/home/HomeHeader.astro
+++ b/src/components/home/HomeHeader.astro
@@ -424,8 +424,9 @@ const navLinks = [
       link.addEventListener('click', closeNav);
     });
 
-    desktopQuery.addEventListener?.('change', handleDesktopChange);
-    desktopQuery.addListener?.(handleDesktopChange);
+    if (typeof desktopQuery.addEventListener === 'function') {
+      desktopQuery.addEventListener('change', handleDesktopChange);
+    }
 
     updateNavState(isOpen);
 
@@ -436,8 +437,9 @@ const navLinks = [
       linkElements.forEach((link) => {
         link.removeEventListener('click', closeNav);
       });
-      desktopQuery.removeEventListener?.('change', handleDesktopChange);
-      desktopQuery.removeListener?.(handleDesktopChange);
+      if (typeof desktopQuery.removeEventListener === 'function') {
+        desktopQuery.removeEventListener('change', handleDesktopChange);
+      }
       if (themeToggle && desktopThemeTarget) {
         desktopThemeTarget.appendChild(themeToggle);
       }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,7 +2,7 @@
 import '../styles/tokens.css';
 import '../styles/utilities.css';
 import '../styles/animations.css';
-import { ViewTransitions } from 'astro:transitions';
+import { ClientRouter } from 'astro:transitions';
 const {
   title = 'Shyam Ajudia | Infrastructure & Data Engineer',
   description = 'Portfolio highlighting the intersection of molecular biology, large-scale data, and resilient infrastructure.',
@@ -43,7 +43,7 @@ const {
     </script>
   </head>
   <body>
-    <ViewTransitions />
+    <ClientRouter />
     <slot />
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the deprecated `tseslint.config()` helper with a flat config array
- rely on standard media query `addEventListener`/`removeEventListener` hooks in the home header mobile nav setup
- swap the deprecated `ViewTransitions` component for the new `ClientRouter` wrapper

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d08e49cb3c833392a716e6d33ec1d4