### PR TITLE
fix: tighten hero mobile spacing

### DIFF
--- a/src/components/home/HeroSection.astro
+++ b/src/components/home/HeroSection.astro
@@ -158,6 +158,15 @@ const { stats } = Astro.props as Props;
     }
   }
 
+  @media (max-width: 48rem) {
+    .hero {
+      --hero-mobile-padding-start: clamp(var(--space-lg), 3vh, var(--space-xl));
+      padding-block-start: calc(
+        env(safe-area-inset-top, 0px) + var(--hero-mobile-padding-start)
+      );
+    }
+  }
+
   @media (max-width: 720px) {
     .hero__name {
       font-size: clamp(2.75rem, 10vw + 0.6rem, 4.75rem);


### PR DESCRIPTION
## Summary
- reduce the hero section's top padding on narrow viewports to eliminate the blank space on mobile
- include safe-area support so the hero content still clears device notches while sitting closer to the top edge

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d09e5cc87c8333ae4284e257be49a0