### PR TITLE
fix: close mobile nav when tapping outside

### DIFF
--- a/src/components/home/HomeHeader.astro
+++ b/src/components/home/HomeHeader.astro
@@ -454,6 +454,32 @@ const navLinks = [
       }
     };
 
+    const isEventInsideNav = (event) => {
+      const path =
+        typeof event.composedPath === 'function' ? event.composedPath() : null;
+      if (path) {
+        return path.includes(nav) || path.includes(toggle);
+      }
+
+      const target = event.target;
+      return (
+        (target instanceof Node && nav.contains(target)) ||
+        (target instanceof Node && toggle.contains(target))
+      );
+    };
+
+    const onPointerDown = (event) => {
+      if (!isOpen || desktopQuery.matches) {
+        return;
+      }
+
+      if (isEventInsideNav(event)) {
+        return;
+      }
+
+      closeNav();
+    };
+
     const handleDesktopChange = (event) => {
       if (event.matches) {
         isOpen = false;
@@ -465,6 +491,7 @@ const navLinks = [
 
     toggle.addEventListener('click', onToggle);
     window.addEventListener('keydown', onKeydown);
+    window.addEventListener('pointerdown', onPointerDown);
     linkElements.forEach((link) => {
       link.addEventListener('click', closeNav);
     });
@@ -479,6 +506,7 @@ const navLinks = [
       closeNav();
       toggle.removeEventListener('click', onToggle);
       window.removeEventListener('keydown', onKeydown);
+      window.removeEventListener('pointerdown', onPointerDown);
       linkElements.forEach((link) => {
         link.removeEventListener('click', closeNav);
       });


### PR DESCRIPTION
## Summary
- close the mobile navigation when a pointer event occurs outside the menu
- guard the outside-click detection to avoid closing when interacting with nav controls and clean up the listener

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d0ad5dd2a08333ae2929f0500dc3e5