### PR TITLE
test: update project grid coverage after removals

### DIFF
--- a/tests/e2e/components.spec.ts
+++ b/tests/e2e/components.spec.ts
@@ -54,7 +54,7 @@ test.describe('Home page experience', () => {
     await projectsSection.scrollIntoViewIfNeeded();
     await expect(projectsSection).toBeVisible();
 
-    await expect(page.locator('.projects__grid .project-card')).toHaveCount(6);
+    await expect(page.locator('.projects__grid .project-card')).toHaveCount(3);
     await expect(
       page.getByRole('link', { name: 'Read research-style case study →' }),
     ).toBeVisible();


### PR DESCRIPTION
## Summary
- update the Playwright home page check to expect the three remaining project cards

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d0ad2a8b388333a82bc7adc33aa81c