### PR TITLE
fix: rephrase projects copy for services

### DIFF
--- a/src/components/home/ProjectsSection.astro
+++ b/src/components/home/ProjectsSection.astro
@@ -13,10 +13,10 @@ const { projects } = Astro.props as Props;
   <div class="u-container section__heading">
     <div>
       <p class="u-title-overline">Featured Projects</p>
-      <h2>Hybrid programmes bridging lab reality and cloud scale</h2>
+      <h2>Hybrid services connecting lab work to cloud scale</h2>
     </div>
     <p>
-      Core infrastructure programmes that keep my platform running: the GitOps
+      Core infrastructure services keep my platform running: the GitOps
       Kubernetes platform, this portfolio, and the immutable operating system
       powering the nodes underneath.
     </p>


### PR DESCRIPTION
## Summary
- replace the Projects section heading and description to refer to services instead of programs

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d0af9844948333ac17d7d28d91214d