### PR TITLE
chore: shorten hero stat label

### DIFF
--- a/src/content/home.ts
+++ b/src/content/home.ts
@@ -50,7 +50,7 @@ export const heroStats: HeroStat[] = [
   },
   {
     label: 'Efficiency unlocked',
-    value: '3,500+ hours saved',
+    value: '3k+ hours saved',
     context:
       'Systematic workflow automation reclaimed the equivalent of two FTEs across data processing and deployment',
   },


### PR DESCRIPTION
## Summary
- shorten the efficiency hero stat copy to "3k+ hours saved" to prevent wrapping

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d0c1fa6d4883338f83bd46fb573825