### PR TITLE
fix: bundle reveal init and refresh e2e checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -40,8 +40,38 @@ jobs:
       - name: Build
         run: pnpm -s astro build
 
+  e2e-tests:
+    name: End-to-End Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps
+
+      - name: Run e2e tests
+        run: pnpm -s test:e2e
+
   container-smoke-test:
     name: Container Smoke Test
+    needs:
+      - node-checks
+      - e2e-tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/src/components/util/RevealInitializer.svelte
+++ b/src/components/util/RevealInitializer.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { initReveal } from '../../scripts/initReveal';
+
+  onMount(() => {
+    const runReveal = () => initReveal({ threshold: 0, rootMargin: '-6%' });
+
+    runReveal();
+    document.addEventListener('astro:page-load', runReveal);
+
+    return () => {
+      document.removeEventListener('astro:page-load', runReveal);
+    };
+  });
+</script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,6 +7,7 @@ import SkillsSection from '../components/home/SkillsSection.astro';
 import ExperienceSection from '../components/home/ExperienceSection.astro';
 import InsightsSection from '../components/home/InsightsSection.astro';
 import ContactSection from '../components/home/ContactSection.astro';
+import RevealInitializer from '../components/util/RevealInitializer.svelte';
 import {
   heroStats,
   projects,
@@ -29,11 +30,5 @@ import '../styles/pages/home.css';
     <InsightsSection insights={insights} codeSample={codeSample} />
     <ContactSection channels={contactChannels} />
   </main>
-
-  <script type="module" is:inline>
-    import { initReveal } from '../scripts/initReveal';
-
-    // Lower threshold prevents tall sections (like Projects) from remaining hidden too long on mobile.
-    initReveal({ threshold: 0, rootMargin: '-6%' });
-  </script>
+  <RevealInitializer client:load />
 </BaseLayout>

--- a/tests/e2e/components.spec.ts
+++ b/tests/e2e/components.spec.ts
@@ -9,8 +9,33 @@ test.describe('Home page experience', () => {
   test('renders hero content and site navigation', async ({ page }) => {
     await expect(page.locator('html')).toHaveAttribute('lang', 'en');
 
-    await expect(page.locator('.site-header')).toBeVisible();
-    await expect(page.getByRole('banner')).toBeVisible();
+    const header = page.locator('.site-header');
+    await expect(header).toHaveAttribute('data-js', 'site-header');
+
+    const navigation = page.getByRole('navigation', {
+      name: 'Primary navigation',
+    });
+    const navToggle = page.locator('[data-js="nav-toggle"]');
+
+    if (await navToggle.isVisible()) {
+      await navToggle.click();
+      await expect(navigation).toBeVisible();
+    } else {
+      await expect(navigation).toBeVisible();
+    }
+
+    const navLabels = [
+      'Overview',
+      'Projects',
+      'Skills',
+      'Experience',
+      'Insights',
+      'Contact',
+    ];
+
+    for (const label of navLabels) {
+      await expect(navigation.getByRole('link', { name: label })).toBeVisible();
+    }
 
     await expect(page.locator('.hero__title')).toBeVisible();
     await expect(page.getByRole('link', { name: 'Collaborate' })).toBeVisible();
@@ -56,10 +81,18 @@ test.describe('Home page experience', () => {
       page.getByRole('link', { name: 'Read research-style case study →' }),
     ).toBeVisible();
 
-    await expect(page.getByTestId('ic50-visualizer')).toBeVisible();
+    const insightsSection = page.locator('#insights');
+    await insightsSection.scrollIntoViewIfNeeded();
+    await expect(insightsSection).toBeVisible();
+
+    const workbench = page.getByRole('region', {
+      name: 'Sequence analysis tool',
+    });
+    await expect(workbench).toBeVisible();
     await expect(
-      page.getByRole('region', { name: 'Infrastructure health' }),
+      workbench.getByRole('heading', { name: 'Sequence Workbench' }),
     ).toBeVisible();
+    await expect(workbench.getByLabel('DNA Sequence')).toBeVisible();
   });
 
   test('highlights skills, experience, and contact sections', async ({
@@ -104,6 +137,11 @@ test.describe('Home page experience', () => {
     const html = page.locator('html');
     const initialTheme = (await html.getAttribute('data-theme')) ?? 'light';
 
+    const navToggle = page.locator('[data-js="nav-toggle"]');
+    if (await navToggle.isVisible()) {
+      await navToggle.click();
+    }
+
     const themeToggle = page.getByRole('button', { name: /switch to/i });
     await expect(themeToggle).toBeVisible();
     await themeToggle.click();
@@ -118,6 +156,9 @@ test.describe('Home page experience', () => {
 
     await page.reload();
     await expect(html).toHaveAttribute('data-theme', expectedTheme);
+    if (await navToggle.isVisible()) {
+      await navToggle.click();
+    }
     await expect(
       page.getByRole('button', {
         name: new RegExp(`Switch to ${initialTheme} mode`, 'i'),


### PR DESCRIPTION
## Summary
- add a client-loaded `RevealInitializer` component so the home page calls `initReveal` without 404s
- update the home page to mount the initializer and refresh e2e coverage around navigation, insights, and theme persistence

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68d0c5b75588833390714da626afd3bc