### PR TITLE
feat: enhance GC meter accessibility

### DIFF
--- a/src/components/demos/SequenceWorkbench.svelte
+++ b/src/components/demos/SequenceWorkbench.svelte
@@ -138,9 +138,20 @@
 
     <div class="workbench__panel">
       <div>
-        <h4>GC Content</h4>
-        <p><strong>{$gcContent}%</strong> GC across {$cleanSequence.length} bp</p>
-        <div class="meter">
+        <h4 id="gc-content-heading">GC Content</h4>
+        <p id="gc-content-summary">
+          <strong>{$gcContent}%</strong> GC across {$cleanSequence.length} bp
+        </p>
+        <div
+          class="meter"
+          role="progressbar"
+          aria-labelledby="gc-content-heading"
+          aria-describedby="gc-content-summary"
+          aria-valuemin="0"
+          aria-valuemax="100"
+          aria-valuenow={$gcContent}
+          aria-valuetext={`${$gcContent}% GC`}
+        >
           <div class="meter__fill" style={`width: ${Math.min(100, $gcContent)}%`}></div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- mark the GC content meter as a progressbar with descriptive labelling
- expose live aria values that mirror the rendered GC percentage

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d0e072ea1c8333a28f0e1c63efbb15