### PR TITLE
docs: emphasize preview requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 - `pnpm dev` — start local dev server at `http://localhost:4321`.
 - `pnpm build` — production build to `dist/`.
 - `pnpm preview` — preview built site.
-- Always create a preview of the website by running `pnpm build` followed by `pnpm preview --host` when working on tasks; use this preview for screenshots or validations of UI changes.
+- **You MUST ALWAYS generate a preview** of the website by running `pnpm build` followed by `pnpm preview --host` when working on tasks; use this preview for screenshots or validations of UI changes.
 - `pnpm astro` — run Astro CLI; e.g., `pnpm astro check` (static analysis).
 - `pnpm test` / `pnpm test:watch` / `pnpm test:ui` — Vitest run/watch/UI.
 - `pnpm test:coverage` — collect coverage.


### PR DESCRIPTION
## Summary
- strengthen the agent instructions by explicitly requiring a preview to be generated for every task

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build
- pnpm preview --host (manually stopped after verifying the server started)

------
https://chatgpt.com/codex/tasks/task_e_68d1649cff30833395e404dc2c429b5a