### PR TITLE
fix: ensure backdrop covers mobile safe areas

### DIFF
--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -145,10 +145,20 @@
     line-height: 1.6;
     background: var(--color-bg);
     color: var(--color-text);
-    background-image: var(--gradient-backdrop);
-    background-attachment: fixed;
     min-height: 100vh;
     overflow-x: hidden;
+  }
+
+  body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    background: var(--color-bg);
+    background-image: var(--gradient-backdrop);
+    background-size: cover;
+    background-repeat: no-repeat;
   }
 
   ::selection {


### PR DESCRIPTION
## Summary
- render the global backdrop via a fixed body pseudo-element so it stays visible on mobile safe areas
- retain the base body background color while preserving the gradient appearance across themes

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d1692989d48333a89f1a44b6fbe277