### PR TITLE
refactor: extract reusable section header

### DIFF
--- a/src/components/home/ExperienceSection.astro
+++ b/src/components/home/ExperienceSection.astro
@@ -1,4 +1,5 @@
 ---
+import SectionHeader from '../ui/SectionHeader.astro';
 import type { Experience } from '../../content/home';
 
 interface Props {
@@ -9,19 +10,11 @@ const { experiences } = Astro.props as Props;
 ---
 
 <section class="section" id="experience" data-reveal>
-  <div class="u-container section__heading">
-    <div>
-      <p class="u-title-overline">Experience</p>
-      <h2>
-        Career progression from research to technical operations leadership
-      </h2>
-    </div>
-    <p>
-      Roles span academic research, biotechnology, and healthcare IT. Each
-      position strengthened the bridge between scientific discovery and scalable
-      technical implementation.
-    </p>
-  </div>
+  <SectionHeader
+    overline="Experience"
+    title="Career progression from research to technical operations leadership"
+    description="Roles span academic research, biotechnology, and healthcare IT. Each position strengthened the bridge between scientific discovery and scalable technical implementation."
+  />
   <div class="u-container experience">
     {
       experiences.map((job) => (

--- a/src/components/home/InsightsSection.astro
+++ b/src/components/home/InsightsSection.astro
@@ -1,4 +1,5 @@
 ---
+import SectionHeader from '../ui/SectionHeader.astro';
 import SequenceWorkbench from '../demos/SequenceWorkbench.svelte';
 import type { Insight } from '../../content/home';
 
@@ -11,16 +12,11 @@ const { insights, codeSample } = Astro.props as Props;
 ---
 
 <section class="section section--insights" id="insights" data-reveal>
-  <div class="u-container section__heading">
-    <div>
-      <p class="u-title-overline">Technical Insights</p>
-      <h2>Operating principles for reproducible, scalable science</h2>
-    </div>
-    <p>
-      Essays, conference talks, and internal runbooks that translate
-      infrastructure decisions into scientific leverage.
-    </p>
-  </div>
+  <SectionHeader
+    overline="Technical Insights"
+    title="Operating principles for reproducible, scalable science"
+    description="Essays, conference talks, and internal runbooks that translate infrastructure decisions into scientific leverage."
+  />
   <div class="u-container insights__grid">
     {
       insights.map((insight) => (

--- a/src/components/home/ProjectsSection.astro
+++ b/src/components/home/ProjectsSection.astro
@@ -1,5 +1,6 @@
 ---
 import ProjectCard from './ProjectCard.astro';
+import SectionHeader from '../ui/SectionHeader.astro';
 import type { Project } from '../../content/home';
 
 interface Props {
@@ -10,17 +11,11 @@ const { projects } = Astro.props as Props;
 ---
 
 <section class="section projects" id="projects" data-reveal>
-  <div class="u-container section__heading">
-    <div>
-      <p class="u-title-overline">Featured Projects</p>
-      <h2>Hybrid services connecting lab work to cloud scale</h2>
-    </div>
-    <p>
-      Core infrastructure services keep my platform running: the GitOps
-      Kubernetes platform, this portfolio, and the immutable operating system
-      that keeps my personal desktop reproducible.
-    </p>
-  </div>
+  <SectionHeader
+    overline="Featured Projects"
+    title="Hybrid services connecting lab work to cloud scale"
+    description="Core infrastructure services keep my platform running: the GitOps Kubernetes platform, this portfolio, and the immutable operating system that keeps my personal desktop reproducible."
+  />
 
   <div class="u-container projects__grid">
     {projects.map((project) => <ProjectCard project={project} />)}

--- a/src/components/home/SkillsSection.astro
+++ b/src/components/home/SkillsSection.astro
@@ -1,19 +1,14 @@
 ---
 import ApplicationSkills from '../skills/ApplicationSkills.svelte';
+import SectionHeader from '../ui/SectionHeader.astro';
 ---
 
 <section class="section" id="skills" data-reveal>
-  <div class="u-container section__heading">
-    <div>
-      <p class="u-title-overline">Skill Architecture</p>
-      <h2>Capabilities organised by scientific outcome</h2>
-    </div>
-    <p>
-      Choose a lens—scientific computing, infrastructure, data, collaboration—to
-      see how tooling decisions connect directly to scientific velocity and
-      compliance.
-    </p>
-  </div>
+  <SectionHeader
+    overline="Skill Architecture"
+    title="Capabilities organised by scientific outcome"
+    description="Choose a lens—scientific computing, infrastructure, data, collaboration—to see how tooling decisions connect directly to scientific velocity and compliance."
+  />
   <div class="u-container">
     <ApplicationSkills client:visible />
   </div>

--- a/src/components/ui/SectionHeader.astro
+++ b/src/components/ui/SectionHeader.astro
@@ -1,0 +1,17 @@
+---
+interface Props {
+  overline: string;
+  title: string;
+  description?: string;
+}
+
+const { overline, title, description } = Astro.props as Props;
+---
+
+<div class="u-container section__heading">
+  <div>
+    <p class="u-title-overline">{overline}</p>
+    <h2>{title}</h2>
+  </div>
+  {description && <p>{description}</p>}
+</div>


### PR DESCRIPTION
## Summary
- add a shared `SectionHeader` component with overline, title, and description props
- replace duplicated section heading markup across home sections to use the new component

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d19abb719883339856150425dac160