### PR TITLE
feat: centralize theme helpers

### DIFF
--- a/src/components/ui/ThemeToggle.svelte
+++ b/src/components/ui/ThemeToggle.svelte
@@ -1,42 +1,32 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import {
+    applyTheme,
+    getPreferredTheme,
+    type ApplyThemeOptions,
+    type Theme,
+  } from '../../scripts/theme';
 
   const themes = [
     { id: 'light', label: 'Light Mode', icon: '☀️' },
     { id: 'dark', label: 'Dark Mode', icon: '🌙' },
   ];
 
-  let theme: 'light' | 'dark' = 'light';
+  let theme: Theme = 'light';
 
-  const applyTheme = (next: 'light' | 'dark') => {
-    const root = document.documentElement;
-    root.dataset.theme = next;
-    root.style.setProperty('color-scheme', next === 'dark' ? 'dark' : 'light');
-    try {
-      localStorage.setItem('portfolio-theme', next);
-    } catch (error) {
-      /* localStorage may be disabled; ignore */
-    }
+  const setTheme = (next: Theme, options?: ApplyThemeOptions) => {
+    applyTheme(next, options);
     theme = next;
   };
 
   const toggleTheme = () => {
     const next = theme === 'light' ? 'dark' : 'light';
-    applyTheme(next);
+    setTheme(next);
   };
 
   onMount(() => {
-    try {
-      const stored = localStorage.getItem('portfolio-theme');
-      if (stored === 'light' || stored === 'dark') {
-        theme = stored;
-      } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        theme = 'dark';
-      }
-    } catch (error) {
-      theme = document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light';
-    }
-    applyTheme(theme);
+    const preferred = getPreferredTheme();
+    setTheme(preferred);
   });
 </script>
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -24,22 +24,11 @@ const {
       rel="stylesheet"
     />
     <meta name="generator" content={Astro.generator} />
-    <script is:inline>
-      try {
-        const storedTheme = localStorage.getItem('portfolio-theme');
-        const prefersDark = window.matchMedia(
-          '(prefers-color-scheme: dark)',
-        ).matches;
-        const theme = storedTheme ?? (prefersDark ? 'dark' : 'light');
-        document.documentElement.dataset.theme = theme;
-        document.documentElement.style.setProperty(
-          'color-scheme',
-          theme === 'dark' ? 'dark' : 'light',
-        );
-      } catch (error) {
-        document.documentElement.dataset.theme = 'light';
-        document.documentElement.style.setProperty('color-scheme', 'light');
-      }
+    <script type="module" is:inline>
+      import { applyTheme, getPreferredTheme } from '/src/scripts/theme.ts';
+
+      const theme = getPreferredTheme();
+      applyTheme(theme, { persist: false });
     </script>
   </head>
   <body>

--- a/src/scripts/theme.ts
+++ b/src/scripts/theme.ts
@@ -1,0 +1,66 @@
+export type Theme = 'light' | 'dark';
+
+const STORAGE_KEY = 'portfolio-theme';
+const DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)';
+
+const isTheme = (value: unknown): value is Theme =>
+  value === 'light' || value === 'dark';
+
+export const getPreferredTheme = (): Theme => {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return 'light';
+  }
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (isTheme(stored)) {
+      return stored;
+    }
+  } catch {
+    // localStorage may be unavailable; ignore and fall back
+  }
+
+  if (typeof window.matchMedia === 'function') {
+    try {
+      if (window.matchMedia(DARK_MEDIA_QUERY).matches) {
+        return 'dark';
+      }
+    } catch {
+      // matchMedia might throw in unsupported environments
+    }
+  }
+
+  const datasetTheme = document.documentElement.dataset.theme;
+  if (isTheme(datasetTheme)) {
+    return datasetTheme;
+  }
+
+  return 'light';
+};
+
+export interface ApplyThemeOptions {
+  persist?: boolean;
+}
+
+export const applyTheme = (
+  theme: Theme,
+  { persist = true }: ApplyThemeOptions = {},
+): void => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const root = document.documentElement;
+  root.dataset.theme = theme;
+  root.style.setProperty('color-scheme', theme === 'dark' ? 'dark' : 'light');
+
+  if (!persist) {
+    return;
+  }
+
+  try {
+    localStorage.setItem(STORAGE_KEY, theme);
+  } catch {
+    // localStorage may be unavailable; ignore persistence failures
+  }
+};


### PR DESCRIPTION
## Summary
- add a shared browser-safe theme helper that derives preferences and writes dataset/color-scheme updates
- update the base layout inline module to import the helper for early theme application
- refactor the ThemeToggle component to reuse the shared helper for initialization and toggling

## Testing
- pnpm dev --host 0.0.0.0 (manual verification of light/dark persistence)
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build
- pnpm preview --host 0.0.0.0

------
https://chatgpt.com/codex/tasks/task_e_68d19ac8b7f08333a636f162c1d60033