### PR TITLE
feat: add hero see more scroll control

### DIFF
--- a/src/components/home/HeroSection.astro
+++ b/src/components/home/HeroSection.astro
@@ -27,6 +27,25 @@ const { stats } = Astro.props as Props;
       </p>
       <div class="hero__actions">
         <a class="hero__cta" href="#contact">Collaborate</a>
+        <a class="hero__scroll" href="#projects">
+          <span>See more</span>
+          <svg aria-hidden="true" viewBox="0 0 24 24" role="presentation">
+            <path
+              d="M6 9.75 12 15l6-5.25"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.6"
+              stroke-linecap="round"
+              stroke-linejoin="round"></path>
+            <path
+              d="M12 4.5v10.5"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.6"
+              stroke-linecap="round"
+              stroke-linejoin="round"></path>
+          </svg>
+        </a>
       </div>
     </div>
     <div class="hero__metrics anim-stagger">
@@ -108,6 +127,52 @@ const { stats } = Astro.props as Props;
   .hero__cta:hover,
   .hero__cta:focus-visible {
     transform: translateY(-2px);
+  }
+
+  .hero__scroll {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.75rem 1.3rem;
+    border-radius: 999px;
+    border: 1px solid
+      color-mix(in oklab, var(--color-border) 65%, transparent 35%);
+    background: color-mix(in oklab, var(--color-surface) 92%, transparent 8%);
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 0.85rem;
+    transition:
+      border-color var(--duration-base) var(--ease-smooth),
+      background var(--duration-base) var(--ease-smooth),
+      color var(--duration-base) var(--ease-smooth);
+  }
+
+  .hero__scroll svg {
+    width: 1.25rem;
+    height: 1.25rem;
+    flex-shrink: 0;
+    transition: transform var(--duration-base) var(--ease-smooth);
+  }
+
+  .hero__scroll:hover,
+  .hero__scroll:focus-visible {
+    border-color: color-mix(
+      in oklab,
+      var(--color-primary) 45%,
+      transparent 55%
+    );
+    background: color-mix(
+      in oklab,
+      var(--color-surface-strong) 25%,
+      transparent 75%
+    );
+    color: var(--color-text);
+  }
+
+  .hero__scroll:hover svg,
+  .hero__scroll:focus-visible svg {
+    transform: translateY(4px);
   }
 
   .hero__metrics {

--- a/tests/e2e/components.spec.ts
+++ b/tests/e2e/components.spec.ts
@@ -39,6 +39,9 @@ test.describe('Home page experience', () => {
 
     await expect(page.locator('.hero__title')).toBeVisible();
     await expect(page.getByRole('link', { name: 'Collaborate' })).toBeVisible();
+    const seeMoreLink = page.getByRole('link', { name: 'See more' });
+    await expect(seeMoreLink).toBeVisible();
+    await expect(seeMoreLink).toHaveAttribute('href', '#projects');
 
     await expect(page.locator('.hero__metric')).toHaveCount(3);
   });


### PR DESCRIPTION
## Summary
- add a "See more" control under the collaborate CTA that scrolls to the projects section
- style the new button with an animated downward arrow to communicate continued content
- cover the new link with the existing Playwright smoke test to ensure it remains visible and points to projects

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build
- pnpm preview --host

------
https://chatgpt.com/codex/tasks/task_e_68d19cf7dcac833397d09caa36ead76b