### PR TITLE
refactor: centralize project detail rendering

### DIFF
--- a/src/components/home/ProjectCard.astro
+++ b/src/components/home/ProjectCard.astro
@@ -1,11 +1,14 @@
 ---
 import type { Project } from '../../content/home';
+import ProjectDetailList from './ProjectDetailList.astro';
+import { getProjectDetails } from './projectDetails';
 
 interface Props {
   project: Project;
 }
 
 const { project } = Astro.props as Props;
+const details = getProjectDetails(project);
 ---
 
 {
@@ -27,32 +30,11 @@ const { project } = Astro.props as Props;
                 <h4>Solution</h4>
                 <p>{project.solution}</p>
               </div>
-              <div>
-                <h4>Stack</h4>
-                <ul class="project-card__tags">
-                  {project.stack.map((item) => (
-                    <li>{item}</li>
-                  ))}
-                </ul>
-              </div>
+              <ProjectDetailList detail={details.stack} wrapper="div" />
             </div>
             <div class="project-card__footer">
-              <div>
-                <h4>Results</h4>
-                <ul>
-                  {project.results.map((result) => (
-                    <li>{result}</li>
-                  ))}
-                </ul>
-              </div>
-              <div>
-                <h4>Technical Challenges</h4>
-                <ul>
-                  {project.challenges.map((item) => (
-                    <li>{item}</li>
-                  ))}
-                </ul>
-              </div>
+              <ProjectDetailList detail={details.results} wrapper="div" />
+              <ProjectDetailList detail={details.challenges} wrapper="div" />
             </div>
             {project.link && (
               <a class="project-card__link" href={project.link}>
@@ -79,24 +61,9 @@ const { project } = Astro.props as Props;
               </div>
             </dl>
             <div class="project-card__meta">
-              <h4>Stack</h4>
-              <ul class="project-card__tags">
-                {project.stack.map((item) => (
-                  <li>{item}</li>
-                ))}
-              </ul>
-              <h4>Results</h4>
-              <ul>
-                {project.results.map((item) => (
-                  <li>{item}</li>
-                ))}
-              </ul>
-              <h4>Technical Challenges</h4>
-              <ul>
-                {project.challenges.map((item) => (
-                  <li>{item}</li>
-                ))}
-              </ul>
+              <ProjectDetailList detail={details.stack} />
+              <ProjectDetailList detail={details.results} />
+              <ProjectDetailList detail={details.challenges} />
             </div>
           </article>
         );
@@ -114,24 +81,9 @@ const { project } = Astro.props as Props;
               <p>{project.solution}</p>
             </div>
             <div class="project-card__meta">
-              <h4>Stack</h4>
-              <ul class="project-card__tags">
-                {project.stack.map((item) => (
-                  <li>{item}</li>
-                ))}
-              </ul>
-              <h4>Results</h4>
-              <ul>
-                {project.results.map((item) => (
-                  <li>{item}</li>
-                ))}
-              </ul>
-              <h4>Technical Challenges</h4>
-              <ul>
-                {project.challenges.map((item) => (
-                  <li>{item}</li>
-                ))}
-              </ul>
+              <ProjectDetailList detail={details.stack} />
+              <ProjectDetailList detail={details.results} />
+              <ProjectDetailList detail={details.challenges} />
             </div>
           </article>
         );

--- a/src/components/home/ProjectDetailList.astro
+++ b/src/components/home/ProjectDetailList.astro
@@ -1,0 +1,32 @@
+---
+import type { ProjectDetail } from './projectDetails';
+
+interface Props {
+  detail: ProjectDetail;
+  wrapper?: 'div';
+}
+
+const { detail, wrapper } = Astro.props as Props;
+---
+
+{
+  wrapper === 'div' ? (
+    <div>
+      <h4>{detail.title}</h4>
+      <ul class={detail.listClass ?? undefined}>
+        {detail.items.map((item) => (
+          <li>{item}</li>
+        ))}
+      </ul>
+    </div>
+  ) : (
+    <>
+      <h4>{detail.title}</h4>
+      <ul class={detail.listClass ?? undefined}>
+        {detail.items.map((item) => (
+          <li>{item}</li>
+        ))}
+      </ul>
+    </>
+  )
+}

--- a/src/components/home/projectDetails.ts
+++ b/src/components/home/projectDetails.ts
@@ -1,0 +1,32 @@
+import type { Project } from '../../content/home';
+
+export type ProjectDetail = {
+  title: string;
+  items: readonly string[];
+  listClass?: string;
+};
+
+export type ProjectDetailMap = Record<
+  'stack' | 'results' | 'challenges',
+  ProjectDetail
+>;
+
+export function getProjectDetails(
+  project: Pick<Project, 'stack' | 'results' | 'challenges'>,
+): ProjectDetailMap {
+  return {
+    stack: {
+      title: 'Stack',
+      items: project.stack,
+      listClass: 'project-card__tags',
+    },
+    results: {
+      title: 'Results',
+      items: project.results,
+    },
+    challenges: {
+      title: 'Technical Challenges',
+      items: project.challenges,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- centralize the stack, results, and challenges metadata in a reusable helper for ProjectCard
- render each detail list through a dedicated ProjectDetailList component while preserving layout-specific wrappers

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build
- pnpm preview --host

------
https://chatgpt.com/codex/tasks/task_e_68d19ab476dc833395c2815d296cf296