### PR TITLE
chore: streamline Playwright e2e startup

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps
 
+      - name: Build
+        run: pnpm -s build
+
       - name: Run e2e tests
         env:
           PLAYWRIGHT_COLOR_SCHEME: light

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,7 +37,9 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'pnpm build && pnpm preview',
+    command: 'pnpm preview --host 0.0.0.0 --port 4321',
     port: 4321,
+    timeout: 120_000,
+    reuseExistingServer: !process.env.CI,
   },
 });


### PR DESCRIPTION
## Summary
- prebuild the production bundle in the e2e workflow before launching tests
- update Playwright to reuse a preview server with a longer startup timeout

## Testing
- pnpm build
- pnpm test:e2e


------
https://chatgpt.com/codex/tasks/task_e_68d1b02b8ad88333bec3e4bf7333fcc5