### PR TITLE
ci: add preview screenshot comment workflow

### DIFF
--- a/.github/workflows/pr-preview-screenshot.yml
+++ b/.github/workflows/pr-preview-screenshot.yml
@@ -1,0 +1,126 @@
+name: PR Preview Screenshot
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Generate Preview Screenshot
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright (Chromium only)
+        run: pnpm exec playwright install chromium --with-deps
+
+      - name: Capture homepage screenshot
+        id: capture
+        env:
+          PREVIEW_SCREENSHOT: 'true'
+          PREVIEW_SCREENSHOT_PATH: artifacts/pr-preview.jpg
+        run: pnpm exec playwright test tests/e2e/pr-preview.spec.ts --project=chromium --reporter=line
+
+      - name: Upload screenshot artifact
+        if: ${{ steps.capture.outcome == 'success' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-preview-screenshot
+          path: artifacts/pr-preview.jpg
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Encode screenshot
+        if: ${{ steps.capture.outcome == 'success' }}
+        id: encode
+        run: |
+          echo "base64=$(base64 -w0 artifacts/pr-preview.jpg)" >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview on PR
+        if: ${{ steps.capture.outcome == 'success' && steps.encode.outputs.base64 != '' }}
+        uses: actions/github-script@v7
+        env:
+          SCREENSHOT_BASE64: ${{ steps.encode.outputs.base64 }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const marker = '<!-- preview-screenshot -->';
+            const image = process.env.SCREENSHOT_BASE64;
+            const { owner, repo } = context.repo;
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const body = [
+              marker,
+              '## 🔍 Preview Screenshot',
+              '',
+              '<details>',
+              '<summary>Expand to view</summary>',
+              '',
+              `![Homepage preview](data:image/jpeg;base64,${image})`,
+              '',
+              '</details>',
+              '',
+              `[⬇️ Download the screenshot artifact](${runUrl})`,
+              '',
+              '_This comment is updated automatically when the PR changes._',
+            ].join('\n');
+            const issue_number = context.issue.number;
+            if (!issue_number) {
+              core.info('No pull request found in context; skipping comment.');
+              return;
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find(
+              (comment) => comment.body?.includes(marker) && comment.user?.type === 'Bot',
+            );
+
+            try {
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body,
+                });
+                core.info(`Updated preview comment (ID: ${existing.id}).`);
+              } else {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number,
+                  body,
+                });
+                core.info('Created preview comment.');
+              }
+            } catch (error) {
+              core.warning(`Unable to publish preview comment: ${error.message}`);
+            }

--- a/tests/e2e/pr-preview.spec.ts
+++ b/tests/e2e/pr-preview.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+import { mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+const shouldCapture = process.env.PREVIEW_SCREENSHOT === 'true';
+const defaultPath = 'test-results/previews/pr-home.jpg';
+
+test.describe('pr preview screenshot', () => {
+  test.skip(!shouldCapture, 'Preview screenshot generation runs only in CI');
+
+  test('captures the homepage preview', async ({ page }) => {
+    const screenshotTarget = process.env.PREVIEW_SCREENSHOT_PATH ?? defaultPath;
+    const absolutePath = resolve(screenshotTarget);
+    mkdirSync(dirname(absolutePath), { recursive: true });
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('main')).toBeVisible();
+
+    const buffer = await page.screenshot({
+      path: absolutePath,
+      fullPage: true,
+      type: 'jpeg',
+      quality: 80,
+    });
+
+    test.info().attach('preview-screenshot', {
+      body: buffer,
+      contentType: 'image/jpeg',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a Playwright spec that captures the homepage screenshot when the preview workflow requests it
- add a pull_request workflow that installs Playwright, captures the screenshot, uploads it, and comments the image plus artifact link on the PR

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d1c0a65d20833390526c12c9140f3f