### PR TITLE
chore: make e2e preview use existing build

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -64,9 +64,13 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps
 
+      - name: Build
+        run: pnpm -s build
+
       - name: Run e2e tests
         env:
           PLAYWRIGHT_COLOR_SCHEME: light
+          PLAYWRIGHT_SKIP_BUILD: '1'
         run: pnpm -s test:e2e
 
   container-smoke-test:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage --run",
+    "pretest:e2e": "node ./scripts/ensure-dist.mjs",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "check:astro": "astro check",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage --run",
-    "pretest:e2e": "node ./scripts/ensure-dist.mjs",
+    "pretest:e2e": "node ./scripts/ensure-playwright-browsers.mjs && node ./scripts/ensure-dist.mjs",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "check:astro": "astro check",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,7 +37,9 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'pnpm build && pnpm preview',
+    command: 'pnpm preview --host 0.0.0.0 --port 4321',
     port: 4321,
+    timeout: 120_000,
+    reuseExistingServer: !process.env.CI,
   },
 });

--- a/scripts/ensure-dist.mjs
+++ b/scripts/ensure-dist.mjs
@@ -1,0 +1,35 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const skipValue = process.env.PLAYWRIGHT_SKIP_BUILD ?? '';
+if (['1', 'true', 'yes'].includes(skipValue.toLowerCase())) {
+  process.exit(0);
+}
+
+const distDir = join(process.cwd(), 'dist');
+let needsBuild = false;
+
+if (!existsSync(distDir)) {
+  needsBuild = true;
+} else {
+  try {
+    const entries = readdirSync(distDir);
+    needsBuild = entries.length === 0;
+  } catch (error) {
+    needsBuild = true;
+  }
+}
+
+if (needsBuild) {
+  const result = spawnSync('pnpm', ['build'], {
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  process.exit(result.status ?? 1);
+}

--- a/scripts/ensure-playwright-browsers.mjs
+++ b/scripts/ensure-playwright-browsers.mjs
@@ -1,0 +1,68 @@
+import { spawnSync } from 'node:child_process';
+
+const skipValue = process.env.PLAYWRIGHT_SKIP_BROWSER_INSTALL ?? '';
+if (['1', 'true', 'yes'].includes(skipValue.toLowerCase())) {
+  process.exit(0);
+}
+
+const pnpmArgs = ['exec', 'playwright', 'install'];
+const shell = process.platform === 'win32';
+
+let supportsCheck = false;
+const helpResult = spawnSync('pnpm', [...pnpmArgs, '--help'], {
+  stdio: ['inherit', 'pipe', 'pipe'],
+  shell,
+});
+
+if (helpResult.error) {
+  throw helpResult.error;
+}
+
+let helpOutput = '';
+if (helpResult.stdout) {
+  helpOutput += helpResult.stdout.toString();
+}
+if (helpResult.stderr) {
+  helpOutput += helpResult.stderr.toString();
+}
+
+supportsCheck = helpOutput.includes('--check');
+
+if (supportsCheck) {
+  const checkResult = spawnSync('pnpm', [...pnpmArgs, '--check'], {
+    stdio: ['inherit', 'pipe', 'pipe'],
+    shell,
+  });
+
+  if (checkResult.error) {
+    throw checkResult.error;
+  }
+
+  if ((checkResult.status ?? 1) === 0) {
+    process.exit(0);
+  }
+
+  if (checkResult.stdout && checkResult.stdout.length > 0) {
+    process.stdout.write(checkResult.stdout.toString());
+  }
+  if (checkResult.stderr && checkResult.stderr.length > 0) {
+    process.stdout.write(checkResult.stderr.toString());
+  }
+}
+
+const installArgs = [...pnpmArgs];
+const depsValue = process.env.PLAYWRIGHT_INSTALL_DEPS ?? '';
+if (['1', 'true', 'yes'].includes(depsValue.toLowerCase())) {
+  installArgs.push('--with-deps');
+}
+
+const installResult = spawnSync('pnpm', installArgs, {
+  stdio: 'inherit',
+  shell,
+});
+
+if (installResult.error) {
+  throw installResult.error;
+}
+
+process.exit(installResult.status ?? 1);


### PR DESCRIPTION
## Summary
- add an automated pretest hook that builds the Astro site when the dist folder is missing
- allow CI to skip the local pretest build since the workflow now produces the bundle explicitly

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build
- pnpm test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68d1b02b8ad88333bec3e4bf7333fcc5