### PR TITLE
ci: fix preview screenshot comment artifact link

### DIFF
--- a/.github/workflows/pr-preview-screenshot.yml
+++ b/.github/workflows/pr-preview-screenshot.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Upload screenshot artifact
         if: ${{ steps.capture.outcome == 'success' }}
+        id: upload
         uses: actions/upload-artifact@v4
         with:
           name: pr-preview-screenshot
@@ -54,36 +55,26 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      - name: Encode screenshot
-        if: ${{ steps.capture.outcome == 'success' }}
-        id: encode
-        run: |
-          echo "base64=$(base64 -w0 artifacts/pr-preview.jpg)" >> "$GITHUB_OUTPUT"
-
       - name: Comment preview on PR
-        if: ${{ steps.capture.outcome == 'success' && steps.encode.outputs.base64 != '' }}
+        if: ${{ steps.capture.outcome == 'success' }}
         uses: actions/github-script@v7
-        env:
-          SCREENSHOT_BASE64: ${{ steps.encode.outputs.base64 }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const marker = '<!-- preview-screenshot -->';
-            const image = process.env.SCREENSHOT_BASE64;
             const { owner, repo } = context.repo;
-            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const artifactUrl = '${{ steps.upload.outputs.artifact-url }}';
+            if (!artifactUrl) {
+              core.warning('No artifact URL available; skipping preview comment.');
+              return;
+            }
             const body = [
               marker,
               '## 🔍 Preview Screenshot',
               '',
-              '<details>',
-              '<summary>Expand to view</summary>',
+              'A fresh preview screenshot is ready for this pull request.',
               '',
-              `![Homepage preview](data:image/jpeg;base64,${image})`,
-              '',
-              '</details>',
-              '',
-              `[⬇️ Download the screenshot artifact](${runUrl})`,
+              `[⬇️ Download the screenshot artifact](${artifactUrl})`,
               '',
               '_This comment is updated automatically when the PR changes._',
             ].join('\n');


### PR DESCRIPTION
## Summary
- add a Playwright spec that captures the homepage screenshot when the preview workflow requests it
- add a pull_request workflow that installs Playwright, captures the screenshot, uploads it, and comments a link to the artifact on the PR
- update the preview comment to link directly to the uploaded artifact so the download works reliably

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d1c75ef9e883339fdf2e1c8e7bf7cb