### PR TITLE
fix: keep stack pills sized to their text

### DIFF
--- a/src/components/home/ProjectsSection.astro
+++ b/src/components/home/ProjectsSection.astro
@@ -82,8 +82,8 @@ const { projects } = Astro.props as Props;
     text-transform: uppercase;
   }
 
-  :global(.project-card__footer ul),
-  :global(.project-card__meta ul) {
+  :global(.project-card__footer ul:not(.project-card__tags)),
+  :global(.project-card__meta ul:not(.project-card__tags)) {
     list-style: none;
     padding: 0;
     margin: 0;


### PR DESCRIPTION
## Summary
- update the project card list styling so the stack tags use their flex layout instead of the grid list layout
- ensure only the non-tag lists in project cards keep the grid styling, preventing the stack pills from stretching full width

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d1f40aac248333949ce59e034f6b26