### PR TITLE
fix: tighten sequence workbench layout

### DIFF
--- a/src/components/demos/SequenceWorkbench.svelte
+++ b/src/components/demos/SequenceWorkbench.svelte
@@ -78,8 +78,10 @@
 <style>
   .workbench {
     display: grid;
-    gap: var(--space-lg);
-    padding: var(--space-lg);
+    gap: clamp(var(--space-md), 3vw, var(--space-lg));
+    padding: clamp(var(--space-md), 4vw, var(--space-lg));
+    max-width: min(60rem, 100%);
+    margin-inline: auto;
     background: color-mix(in oklab, var(--color-surface) 92%, transparent 8%);
     border-radius: var(--radius-lg);
     border: 1px solid color-mix(in oklab, var(--color-border) 60%, transparent 40%);
@@ -96,7 +98,7 @@
 
   .workbench__grid {
     display: grid;
-    gap: var(--space-lg);
+    gap: clamp(var(--space-md), 3vw, var(--space-lg));
   }
 
   label {
@@ -116,7 +118,7 @@
     font-family: "Berkeley Mono", "IBM Plex Mono", "Fira Code", monospace;
     font-size: 0.95rem;
     color: var(--color-text);
-    min-height: 180px;
+    min-height: 160px;
     resize: vertical;
     transition: border-color var(--duration-base) var(--ease-smooth),
       box-shadow var(--duration-base) var(--ease-smooth);

--- a/src/components/home/InsightsSection.astro
+++ b/src/components/home/InsightsSection.astro
@@ -1,14 +1,6 @@
 ---
 import SectionHeader from '../ui/SectionHeader.astro';
 import SequenceWorkbench from '../demos/SequenceWorkbench.svelte';
-import type { Insight } from '../../content/home';
-
-interface Props {
-  insights: Insight[];
-  codeSample: string;
-}
-
-const { insights, codeSample } = Astro.props as Props;
 ---
 
 <section class="section section--insights" id="insights" data-reveal>
@@ -18,21 +10,63 @@ const { insights, codeSample } = Astro.props as Props;
     description="Essays, conference talks, and internal runbooks that translate infrastructure decisions into scientific leverage."
   />
   <div class="u-container insights__grid">
-    {
-      insights.map((insight) => (
-        <article class="insight-card">
-          <h3>{insight.title}</h3>
-          <p>{insight.summary}</p>
-        </article>
-      ))
-    }
-    <article class="insight-card insight-card--code">
-      <h3>Automation blueprint</h3>
-      <p>Workflow manifest powering adaptive sequencing orchestration.</p>
-      <pre><code>{codeSample}</code></pre>
-    </article>
     <article class="insight-card insight-card--demo" data-reveal>
       <SequenceWorkbench client:visible />
+    </article>
+    <article class="insight-card insight-card--upcoming" data-reveal>
+      <header class="insight-card__header">
+        <span class="insight-card__badge insight-card__badge--soon"
+          >Coming Soon</span
+        >
+        <h3>Kubernetes Homelab Deep Dive</h3>
+      </header>
+      <p>
+        Interactive exploration of my production GitOps setup. Walk through Flux
+        deployments, Infisical secrets management, and how this portfolio runs
+        on self-hosted infrastructure.
+      </p>
+      <div
+        class="insight-card__visual insight-card__visual--homelab"
+        aria-hidden="true"
+      >
+        <div class="homelab-core">⎈</div>
+        <div class="homelab-nodes">
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
+      </div>
+    </article>
+    <article class="insight-card insight-card--upcoming" data-reveal>
+      <header class="insight-card__header">
+        <span class="insight-card__badge insight-card__badge--soon"
+          >Coming Soon</span
+        >
+        <h3>Try Nextflow on My Cluster</h3>
+      </header>
+      <p>
+        Launch a test bioinformatics pipeline directly on my Kubernetes cluster.
+        Watch real-time logs, resource usage, and execution graphs. Safe sandbox
+        environment for exploring cloud-native genomics.
+      </p>
+      <div
+        class="insight-card__visual insight-card__visual--nextflow"
+        aria-hidden="true"
+      >
+        <div class="terminal">
+          <div class="terminal__header">
+            <span></span>
+            <span></span>
+            <span></span>
+          </div>
+          <div class="terminal__body">
+            <span class="line line--prompt"></span>
+            <span class="line"></span>
+            <span class="line"></span>
+            <span class="line line--progress"></span>
+          </div>
+        </div>
+      </div>
     </article>
   </div>
 </section>
@@ -65,24 +99,184 @@ const { insights, codeSample } = Astro.props as Props;
     font-size: var(--heading-md);
   }
 
-  .insight-card--code pre {
-    background: var(--color-code-bg);
-    color: var(--color-code-text);
-    padding: var(--space-md);
-    border-radius: var(--radius-md);
-    box-shadow: var(--shadow-md);
-    overflow-x: auto;
+  .insight-card__header {
+    display: grid;
+    gap: var(--space-xs);
   }
 
-  .insight-card--code code {
-    font-size: 0.9rem;
-    line-height: 1.6;
+  .insight-card__badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 0.25rem 0.65rem;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--color-primary) 65%, transparent 35%);
+    color: var(--color-bg);
+    box-shadow: 0 6px 12px -10px var(--color-shadow);
+    width: fit-content;
+  }
+
+  .insight-card__badge--soon {
+    background: linear-gradient(
+      135deg,
+      color-mix(in oklab, #ffb347 80%, transparent) 0%,
+      color-mix(in oklab, #ff7e5f 80%, transparent) 100%
+    );
+    color: var(--color-text);
   }
 
   .insight-card--demo {
     padding: 0;
     border: none;
     background: none;
+    width: min(100%, 64rem);
+    margin-inline: auto;
+  }
+
+  .insight-card--upcoming {
+    position: relative;
+  }
+
+  .insight-card--upcoming p {
+    color: var(--color-text-muted);
+  }
+
+  .insight-card__visual {
+    border-radius: var(--radius-md);
+    border: 1px dashed
+      color-mix(in oklab, var(--color-border) 60%, transparent 40%);
+    background: color-mix(
+      in oklab,
+      var(--color-surface-strong) 25%,
+      transparent 75%
+    );
+    padding: var(--space-md);
+    margin-top: auto;
+  }
+
+  .insight-card__visual--homelab {
+    display: grid;
+    gap: var(--space-md);
+    justify-items: center;
+    padding-block: var(--space-lg);
+  }
+
+  .homelab-core {
+    display: grid;
+    place-items: center;
+    width: 72px;
+    height: 72px;
+    border-radius: 50%;
+    background: radial-gradient(
+      circle at top,
+      color-mix(in oklab, var(--color-science-purple) 75%, transparent) 0%,
+      color-mix(in oklab, var(--color-primary) 45%, transparent) 100%
+    );
+    color: color-mix(in oklab, var(--color-bg) 85%, transparent 15%);
+    font-size: 2.5rem;
+    box-shadow: var(--shadow-sm);
+  }
+
+  .homelab-nodes {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+  }
+
+  .homelab-nodes span {
+    width: 44px;
+    height: 32px;
+    border-radius: var(--radius-sm);
+    background: color-mix(
+      in oklab,
+      var(--color-primary) 35%,
+      var(--color-surface-muted) 65%
+    );
+    box-shadow: inset 0 0 0 1px
+      color-mix(in oklab, var(--color-border) 40%, transparent 60%);
+  }
+
+  .insight-card__visual--nextflow {
+    display: grid;
+    padding: 0;
+  }
+
+  .terminal {
+    border-radius: var(--radius-md);
+    border: 1px solid
+      color-mix(in oklab, var(--color-border) 65%, transparent 35%);
+    background: color-mix(
+      in oklab,
+      var(--color-surface-strong) 55%,
+      var(--color-surface) 45%
+    );
+    overflow: hidden;
+    box-shadow: var(--shadow-sm);
+  }
+
+  .terminal__header {
+    display: flex;
+    gap: 0.4rem;
+    padding: 0.55rem;
+    background: linear-gradient(
+      135deg,
+      color-mix(in oklab, var(--color-surface-muted) 75%, transparent) 0%,
+      color-mix(in oklab, var(--color-surface) 85%, transparent) 100%
+    );
+  }
+
+  .terminal__header span {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: color-mix(
+      in oklab,
+      var(--color-text-muted) 30%,
+      transparent 70%
+    );
+  }
+
+  .terminal__body {
+    display: grid;
+    gap: 0.5rem;
+    padding: var(--space-md);
+    background: radial-gradient(
+      circle at top left,
+      color-mix(in oklab, var(--color-surface-muted) 20%, transparent) 0%,
+      color-mix(in oklab, var(--color-surface) 90%, transparent) 100%
+    );
+  }
+
+  .line {
+    height: 10px;
+    border-radius: 4px;
+    background: color-mix(
+      in oklab,
+      var(--color-text-muted) 35%,
+      transparent 65%
+    );
+  }
+
+  .line--prompt {
+    width: 80%;
+    background: linear-gradient(
+      90deg,
+      color-mix(in oklab, var(--color-science-green) 65%, transparent) 0%,
+      color-mix(in oklab, var(--color-text-muted) 30%, transparent) 100%
+    );
+  }
+
+  .line--progress {
+    width: 60%;
+    background: linear-gradient(
+      90deg,
+      color-mix(in oklab, var(--color-primary) 70%, transparent) 0%,
+      color-mix(in oklab, var(--color-science-purple) 60%, transparent) 100%
+    );
   }
 
   @media (min-width: 960px) {
@@ -90,16 +284,12 @@ const { insights, codeSample } = Astro.props as Props;
       grid-template-columns: repeat(12, 1fr);
     }
 
-    .insight-card {
-      grid-column: span 4;
-    }
-
-    .insight-card--code {
-      grid-column: span 5;
-    }
-
     .insight-card--demo {
-      grid-column: span 7;
+      grid-column: span 12;
+    }
+
+    .insight-card--upcoming {
+      grid-column: span 6;
     }
   }
 </style>

--- a/src/content/home.ts
+++ b/src/content/home.ts
@@ -24,11 +24,6 @@ export type Experience = {
   impact: string[];
 };
 
-export type Insight = {
-  title: string;
-  summary: string;
-};
-
 export type ContactChannel = {
   label: string;
   value: string;
@@ -174,24 +169,6 @@ export const experiences: Experience[] = [
   },
 ];
 
-export const insights: Insight[] = [
-  {
-    title: 'Why Docker Matters for Reproducible Science',
-    summary:
-      'Container digests outlast lab rotations. Provenance-aware builds keep regulators and collaborators aligned on exactly what ran.',
-  },
-  {
-    title: 'Designing Observability for Wet-Lab Reality',
-    summary:
-      'Instrumentation fails physically before dashboards blink. Pair sensor fusion with service-level indicators to detect reagent anomalies first.',
-  },
-  {
-    title: 'From Bench to GPU Cluster',
-    summary:
-      'Latency budgets begin at the pipette. Aligning robotics cycles with autoscalers keeps GPU utilisation high without starving experiments.',
-  },
-];
-
 export const contactChannels: ContactChannel[] = [
   {
     label: 'Email',
@@ -209,26 +186,3 @@ export const contactChannels: ContactChannel[] = [
     href: 'https://www.linkedin.com/in/shyamajudia/',
   },
 ];
-
-export const codeSample = `
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  labels:
-    runbook: ngs-ingest
-spec:
-  entrypoint: orchestrate
-  templates:
-    - name: orchestrate
-      dag:
-        tasks:
-          - name: qc
-            template: fastqc
-          - name: align
-            template: gpu-bwa
-            depends: qc.Succeeded
-            arguments:
-              parameters:
-                - name: lanes
-                  value: {{inputs.parameters.lanes}}
-`;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,9 +12,7 @@ import {
   heroStats,
   projects,
   experiences,
-  insights,
   contactChannels,
-  codeSample,
 } from '../content/home';
 import '../styles/pages/home.css';
 ---
@@ -27,7 +25,7 @@ import '../styles/pages/home.css';
     <ProjectsSection projects={projects} />
     <SkillsSection />
     <ExperienceSection experiences={experiences} />
-    <InsightsSection insights={insights} codeSample={codeSample} />
+    <InsightsSection />
     <ContactSection channels={contactChannels} />
   </main>
   <RevealInitializer client:load />


### PR DESCRIPTION
## Summary
- redesign the Technical Insights section around the live Sequence Workbench demo and upcoming platform engineering spotlights
- clean up home page props and related content exports that are no longer required
- tune the Sequence Workbench card sizing to reduce excess whitespace

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d1fa9ecf3083339498773c53d73f43