### PR TITLE
feat: make navigation sticky across devices

### DIFF
--- a/src/components/home/HomeHeader.astro
+++ b/src/components/home/HomeHeader.astro
@@ -67,8 +67,13 @@ const navLinks = [
       var(--color-surface) 65%
     );
     border-bottom: 1px solid var(--color-border);
-    position: relative;
+    position: sticky;
+    top: 0;
+    inset-inline: 0;
     z-index: 10;
+    padding-block-start: var(--safe-area-top, 0px);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
   }
 
   .site-header__inner {
@@ -192,6 +197,8 @@ const navLinks = [
       --safe-area-right: env(safe-area-inset-right, 0px);
       --mobile-nav-offset: clamp(var(--space-sm), 4vw, var(--space-lg));
       --mobile-toggle-size: clamp(3.25rem, 11vw, 3.75rem);
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
     }
 
     .site-header__inner {


### PR DESCRIPTION
## Summary
- make the site header sticky so navigation stays visible on scroll with a subtle blur treatment
- preserve mobile styling by resetting the blur while honoring the safe-area inset

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2ce74a9108333a6ec2495662e8f71