### PR TITLE
style: redesign theme toggle to match site aesthetic

### DIFF
--- a/src/components/ui/ThemeToggle.svelte
+++ b/src/components/ui/ThemeToggle.svelte
@@ -7,9 +7,9 @@
     type Theme,
   } from '../../scripts/theme';
 
-  const themes = [
-    { id: 'light', label: 'Light Mode', icon: '☀️' },
-    { id: 'dark', label: 'Dark Mode', icon: '🌙' },
+  const themeOptions: Array<{ id: Theme; label: string }> = [
+    { id: 'light', label: 'Light' },
+    { id: 'dark', label: 'Dark' },
   ];
 
   let theme: Theme = 'light';
@@ -31,86 +31,174 @@
 </script>
 
 <button
-  class="toggle"
+  class="theme-toggle"
   type="button"
+  data-theme={theme}
   on:click={toggleTheme}
+  aria-pressed={theme === 'dark'}
   aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
 >
-  {#each themes as option}
-    <span class:active={option.id === theme} aria-hidden={option.id === theme ? 'false' : 'true'}>
-      {option.icon}
-    </span>
-  {/each}
-  <span class="toggle__label">{theme === 'light' ? 'Light' : 'Dark'}</span>
+  <span class="theme-toggle__track" aria-hidden="true">
+    <span class="theme-toggle__indicator"></span>
+    {#each themeOptions as option}
+      <span class:active={option.id === theme} class="theme-toggle__option" data-theme={option.id}>
+        <span class="theme-toggle__icon" aria-hidden="true">
+          {#if option.id === 'light'}
+            <svg viewBox="0 0 24 24" role="presentation">
+              <circle cx="12" cy="12" r="4.25" fill="none" stroke="currentColor" stroke-width="1.5" />
+              <path
+                d="M12 3v2.5M12 18.5V21M4.5 12H7M17 12h2.5M6.4 6.4l1.8 1.8M15.8 15.8l1.8 1.8M6.4 17.6l1.8-1.8M15.8 8.2l1.8-1.8"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+              />
+            </svg>
+          {:else}
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path
+                d="M18.4 14.6a6.5 6.5 0 0 1-7-9.1 7 7 0 1 0 7 9.1Z"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          {/if}
+        </span>
+        <span class="theme-toggle__label">{option.label}</span>
+      </span>
+    {/each}
+  </span>
 </button>
 
 <style>
-  .toggle {
+  .theme-toggle {
+    --toggle-padding: 0.35rem;
+    --indicator-x: 0%;
     position: relative;
     display: inline-flex;
-    align-items: center;
-    gap: 0.75rem;
-    border: 1px solid color-mix(in oklab, var(--color-border) 75%, var(--color-primary-soft) 25%);
-    border-radius: 999px;
-    padding: 0.55rem 1.15rem;
-    background: color-mix(in oklab, var(--color-surface-strong) 60%, var(--color-surface) 40%);
-    color: var(--color-text);
-    font-family: var(--font-sans);
-    font-size: 0.9rem;
+    border: none;
+    background: none;
+    padding: 0;
     cursor: pointer;
-    transition: transform var(--duration-base) var(--ease-smooth),
+    font: inherit;
+    color: inherit;
+  }
+
+  .theme-toggle[data-theme='dark'] {
+    --indicator-x: 100%;
+  }
+
+  .theme-toggle:focus-visible {
+    outline: 3px solid color-mix(in oklab, var(--color-primary) 30%, transparent 70%);
+    outline-offset: 4px;
+  }
+
+  .theme-toggle__track {
+    position: relative;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: center;
+    border-radius: calc(var(--radius-lg) + 6px);
+    padding: var(--toggle-padding);
+    border: 1px solid color-mix(in oklab, var(--color-border) 72%, transparent 28%);
+    background: linear-gradient(
+      135deg,
+      color-mix(in oklab, var(--color-surface) 85%, transparent 15%),
+      color-mix(in oklab, var(--color-surface-strong) 45%, var(--color-surface) 55%)
+    );
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    gap: 0;
+    min-width: 11rem;
+    transition: border-color var(--duration-base) var(--ease-smooth),
       box-shadow var(--duration-base) var(--ease-smooth),
-      border-color var(--duration-base) var(--ease-smooth);
+      background var(--duration-base) var(--ease-smooth);
   }
 
-  .toggle:hover,
-  .toggle:focus-visible {
-    transform: translateY(-1px);
-    box-shadow: 0 12px 24px -18px rgba(0, 0, 0, 0.5);
-    border-color: color-mix(in oklab, var(--color-primary) 55%, transparent 45%);
+  .theme-toggle:hover .theme-toggle__track,
+  .theme-toggle:focus-visible .theme-toggle__track {
+    border-color: color-mix(in oklab, var(--color-primary) 45%, var(--color-border) 55%);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.16),
+      0 12px 24px -18px var(--color-shadow);
   }
 
-  .toggle:focus-visible {
-    outline: 3px solid color-mix(in oklab, var(--color-primary) 25%, transparent 75%);
-    outline-offset: 2px;
+  .theme-toggle__indicator {
+    position: absolute;
+    z-index: 0;
+    top: var(--toggle-padding);
+    bottom: var(--toggle-padding);
+    left: var(--toggle-padding);
+    width: calc(50% - var(--toggle-padding));
+    border-radius: calc(var(--radius-lg) - 4px);
+    background: color-mix(in oklab, var(--color-primary-soft) 55%, var(--color-surface) 45%);
+    box-shadow:
+      0 16px 32px -26px var(--color-shadow),
+      inset 0 1px 0 rgba(255, 255, 255, 0.22);
+    transform: translateX(var(--indicator-x));
+    transition: transform var(--duration-base) var(--ease-emphatic),
+      background var(--duration-base) var(--ease-smooth),
+      box-shadow var(--duration-base) var(--ease-smooth);
   }
 
-  .toggle span {
+  .theme-toggle[data-theme='dark'] .theme-toggle__indicator {
+    background: color-mix(in oklab, var(--color-primary) 55%, var(--color-surface-strong) 45%);
+    box-shadow:
+      0 18px 36px -24px var(--color-shadow),
+      inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  }
+
+  .theme-toggle__option {
+    position: relative;
+    z-index: 1;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 1.75rem;
-    height: 1.75rem;
-    border-radius: 999px;
-    opacity: 0.55;
-    background: color-mix(in oklab, var(--color-surface-muted) 40%, transparent 60%);
-    transition: opacity var(--duration-base) var(--ease-smooth),
-      transform var(--duration-base) var(--ease-smooth),
-      background var(--duration-base) var(--ease-smooth),
-      color var(--duration-base) var(--ease-smooth);
-  }
-
-  .toggle span.active {
-    opacity: 1;
-    transform: translateY(-1px);
-    background: color-mix(in oklab, var(--color-primary) 25%, transparent 75%);
-    color: var(--color-primary-strong);
-    box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--color-primary-strong) 30%, transparent 70%);
-  }
-
-  .toggle__label {
+    gap: 0.45rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: calc(var(--radius-lg) - 2px);
     font-size: 0.78rem;
-    font-weight: 600;
+    font-weight: 500;
     text-transform: uppercase;
-    letter-spacing: 0.2em;
+    letter-spacing: 0.18em;
+    color: var(--color-text-subtle);
+    transition: color var(--duration-base) var(--ease-smooth);
+  }
+
+  .theme-toggle__option.active {
+    color: var(--color-text);
+    font-weight: 600;
+  }
+
+  .theme-toggle__option[data-theme='dark'].active {
+    color: var(--color-primary-strong);
+  }
+
+  .theme-toggle__icon {
+    display: inline-flex;
+    width: 1.4rem;
+    height: 1.4rem;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .theme-toggle__icon svg {
+    width: 100%;
+    height: 100%;
+    stroke: currentColor;
+  }
+
+  .theme-toggle__option:not(.active) .theme-toggle__icon {
     color: var(--color-text-muted);
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .toggle,
-    .toggle span {
+    .theme-toggle__track,
+    .theme-toggle__indicator,
+    .theme-toggle__option {
       transition: none !important;
-      transform: none !important;
     }
   }
 </style>


### PR DESCRIPTION
## Summary
- restyle the theme toggle into a segmented control that mirrors the portfolio's rounded, layered surfaces
- introduce bespoke sun and moon icons with uppercase labels and motion tuned to existing design tokens

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2d016c3448333877d4e22f25ddb81