### PR TITLE
fix: harden external contact links

### DIFF
--- a/src/components/home/ContactSection.astro
+++ b/src/components/home/ContactSection.astro
@@ -48,7 +48,11 @@ const { channels } = Astro.props as Props;
                 class="contact-card__channel"
                 href={channel.href}
                 target={channel.href.startsWith('http') ? '_blank' : undefined}
-                rel={channel.href.startsWith('http') ? 'noreferrer' : undefined}
+                rel={
+                  channel.href.startsWith('http')
+                    ? 'noopener noreferrer'
+                    : undefined
+                }
               >
                 <span>{channel.label}</span>
                 <strong>{channel.value}</strong>


### PR DESCRIPTION
## Summary
- update the contact channel anchors to include both noopener and noreferrer when opening in a new tab

## Testing
- pnpm build
- pnpm preview --host (terminated with Ctrl+C after verifying startup)

------
https://chatgpt.com/codex/tasks/task_e_68d2ef360cec8333b2ab5dc0ed765377