### PR TITLE
feat: animate hero scroll cue

### DIFF
--- a/src/components/home/HeroSection.astro
+++ b/src/components/home/HeroSection.astro
@@ -152,6 +152,8 @@ const { stats } = Astro.props as Props;
     width: 1.25rem;
     height: 1.25rem;
     flex-shrink: 0;
+    transform: translateY(0);
+    animation: hero-scroll-float 2.8s var(--ease-smooth) infinite;
     transition: transform var(--duration-base) var(--ease-smooth);
   }
 
@@ -172,6 +174,7 @@ const { stats } = Astro.props as Props;
 
   .hero__scroll:hover svg,
   .hero__scroll:focus-visible svg {
+    animation: none;
     transform: translateY(4px);
   }
 

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -46,6 +46,16 @@
     }
   }
 
+  @keyframes hero-scroll-float {
+    0%,
+    100% {
+      transform: translateY(0);
+    }
+    50% {
+      transform: translateY(6px);
+    }
+  }
+
   .anim-fade-rise {
     animation: fade-rise var(--duration-slow) var(--ease-emphatic) both;
   }
@@ -97,7 +107,8 @@
     .anim-stagger > *,
     .pulse-ring::after,
     .glow-gradient,
-    .line-trace {
+    .line-trace,
+    .hero__scroll svg {
       animation: none !important;
     }
   }


### PR DESCRIPTION
## Summary
- add a reusable hero scroll float keyframe animation
- animate the hero scroll cue with a gentle idle motion and pause on interaction

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2ef5480e0833393ba05f0afdbb899