### PR TITLE
fix: normalize sequence helpers and sanitize workbench input

### DIFF
--- a/src/components/demos/SequenceWorkbench.svelte
+++ b/src/components/demos/SequenceWorkbench.svelte
@@ -13,6 +13,34 @@
 
   const sequence = writable(defaultSequence);
 
+  const handleSequenceInput = (event: Event) => {
+    const target = event.currentTarget as HTMLTextAreaElement | null;
+    if (!target) return;
+
+    const rawValue = target.value;
+    const sanitizedValue = cleanSequence(rawValue);
+
+    const selectionStart = target.selectionStart ?? rawValue.length;
+    const selectionEnd = target.selectionEnd ?? rawValue.length;
+
+    if (rawValue !== sanitizedValue) {
+      const sanitizedStart = cleanSequence(rawValue.slice(0, selectionStart)).length;
+      const sanitizedEnd = cleanSequence(rawValue.slice(0, selectionEnd)).length;
+
+      target.value = sanitizedValue;
+
+      const applySelection = () => target.setSelectionRange(sanitizedStart, sanitizedEnd);
+
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(applySelection);
+      } else {
+        setTimeout(applySelection, 0);
+      }
+    }
+
+    sequence.set(sanitizedValue);
+  };
+
   const cleanedSequence = derived(sequence, ($sequence) => cleanSequence($sequence));
 
   const gcContent = derived(cleanedSequence, ($sequence) =>
@@ -40,7 +68,8 @@
     <label>
       <span>DNA Sequence</span>
       <textarea
-        bind:value={$sequence}
+        value={$sequence}
+        on:input={handleSequenceInput}
         spellcheck="false"
         rows="6"
         placeholder="Paste genomic sequence"

--- a/src/lib/sequenceUtils.ts
+++ b/src/lib/sequenceUtils.ts
@@ -79,26 +79,28 @@ export const cleanSequence = (sequence: string): string =>
   sequence.replace(/[^acgtACGT]/g, '').toUpperCase();
 
 export const calculateGcContent = (sequence: string): number => {
-  if (!sequence.length) return 0;
-  const gcBases = (sequence.match(/[GC]/g) ?? []).length;
-  return Number(((gcBases / sequence.length) * 100).toFixed(2));
+  const normalizedSequence = cleanSequence(sequence);
+  if (!normalizedSequence.length) return 0;
+  const gcBases = (normalizedSequence.match(/[GC]/g) ?? []).length;
+  return Number(((gcBases / normalizedSequence.length) * 100).toFixed(2));
 };
 
 export const getReverseComplement = (sequence: string): string =>
-  sequence
+  cleanSequence(sequence)
     .split('')
     .reverse()
     .map((base) => COMPLEMENT_MAP[base as ComplementBase] ?? '')
     .join('');
 
 export const translateFrames = (sequence: string): string[] => {
+  const normalizedSequence = cleanSequence(sequence);
   const peptides: string[] = [];
 
   for (let frame = 0; frame < 3; frame += 1) {
     let peptide = '';
 
-    for (let i = frame; i < sequence.length; i += 3) {
-      const codon = sequence.slice(i, i + 3);
+    for (let i = frame; i < normalizedSequence.length; i += 3) {
+      const codon = normalizedSequence.slice(i, i + 3);
       if (codon.length < 3) break;
       peptide += CODON_MAP[codon as Codon] ?? '?';
     }

--- a/tests/unit/components/demos/SequenceWorkbench.spec.ts
+++ b/tests/unit/components/demos/SequenceWorkbench.spec.ts
@@ -16,6 +16,7 @@ describe('SequenceWorkbench', () => {
     await tick();
 
     const cleanedSequence = 'ATGGCTTAA';
+    expect(textarea.value).toBe(cleanedSequence);
     const gcBases =
       (cleanedSequence.match(/[GC]/g)?.length ?? 0) / cleanedSequence.length;
     const expectedGc = Number((gcBases * 100).toFixed(2));
@@ -51,6 +52,7 @@ describe('SequenceWorkbench', () => {
     await fireEvent.input(textarea, { target: { value: '123456---' } });
     await tick();
 
+    expect(textarea.value).toBe('');
     const gcParagraph = screen.getByText('GC Content').nextElementSibling;
     expect(gcParagraph?.textContent).toBe('0% GC across 0 bp');
 

--- a/tests/unit/lib/sequenceUtils.spec.ts
+++ b/tests/unit/lib/sequenceUtils.spec.ts
@@ -35,4 +35,18 @@ describe('sequenceUtils', () => {
     const frames = translateFrames('ATGGCTTAA');
     expect(frames).toEqual(['MA*', 'WL', 'GL']);
   });
+
+  it('normalizes incoming sequences before performing calculations', () => {
+    expect(calculateGcContent('atgc')).toBe(50);
+    expect(calculateGcContent('AtGc')).toBe(50);
+
+    expect(getReverseComplement('atgc')).toBe('GCAT');
+    expect(getReverseComplement('aTgC')).toBe('GCAT');
+
+    const lowerCaseFrames = translateFrames('atggcttaa');
+    const mixedCaseFrames = translateFrames('AtGgCtTaA');
+
+    expect(lowerCaseFrames).toEqual(['MA*', 'WL', 'GL']);
+    expect(mixedCaseFrames).toEqual(['MA*', 'WL', 'GL']);
+  });
 });


### PR DESCRIPTION
## Summary
- normalize inputs inside GC content, reverse complement, and translation helpers
- sanitize Sequence Workbench textarea updates while preserving cursor selection
- expand unit tests to cover lowercase/mixed inputs and sanitized component state

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build
- pnpm preview --host

------
https://chatgpt.com/codex/tasks/task_e_68d2f0160ef48333955ef672ca744e62