### PR TITLE
feat: restrict sequence workbench input to gcat

### DIFF
--- a/src/components/demos/SequenceWorkbench.svelte
+++ b/src/components/demos/SequenceWorkbench.svelte
@@ -13,6 +13,20 @@
 
   const sequence = writable(defaultSequence);
 
+  const baseKeyPattern = /^[GCAT]$/i;
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.defaultPrevented) return;
+
+    const { altKey, ctrlKey, metaKey, key } = event;
+
+    if (altKey || ctrlKey || metaKey) return;
+
+    if (key.length === 1 && !baseKeyPattern.test(key)) {
+      event.preventDefault();
+    }
+  };
+
   const handleSequenceInput = (event: Event) => {
     const target = event.currentTarget as HTMLTextAreaElement | null;
     if (!target) return;
@@ -69,6 +83,7 @@
       <span>DNA Sequence</span>
       <textarea
         value={$sequence}
+        on:keydown={handleKeyDown}
         on:input={handleSequenceInput}
         spellcheck="false"
         rows="6"

--- a/tests/unit/components/demos/SequenceWorkbench.spec.ts
+++ b/tests/unit/components/demos/SequenceWorkbench.spec.ts
@@ -43,6 +43,29 @@ describe('SequenceWorkbench', () => {
     expect(reverseComplementCode?.textContent).toBe('TTAAGCCAT');
   });
 
+  it('prevents invalid nucleotide key presses', () => {
+    render(SequenceWorkbench);
+    const textarea = screen.getByPlaceholderText(
+      'Paste genomic sequence',
+    ) as HTMLTextAreaElement;
+
+    const invalidKeyEvent = new KeyboardEvent('keydown', {
+      key: 'B',
+      bubbles: true,
+      cancelable: true,
+    });
+    const prevented = !textarea.dispatchEvent(invalidKeyEvent);
+    expect(prevented).toBe(true);
+
+    const validKeyEvent = new KeyboardEvent('keydown', {
+      key: 'G',
+      bubbles: true,
+      cancelable: true,
+    });
+    const validPrevented = !textarea.dispatchEvent(validKeyEvent);
+    expect(validPrevented).toBe(false);
+  });
+
   it('handles inputs that strip to an empty sequence gracefully', async () => {
     render(SequenceWorkbench);
     const textarea = screen.getByPlaceholderText(


### PR DESCRIPTION
## Summary
- block invalid nucleotide key presses in the Sequence Workbench textarea to enforce GCAT-only input
- cover the key filtering logic with a unit test alongside existing sanitization checks

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2f4cf636083338c61a35eaf2f0a7f