### PR TITLE
feat: add animated transitions to skills tabs

### DIFF
--- a/src/components/skills/ApplicationSkills.svelte
+++ b/src/components/skills/ApplicationSkills.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { derived, writable } from 'svelte/store';
+  import { fade, fly } from 'svelte/transition';
+  import { cubicOut } from 'svelte/easing';
 
   type SkillCategory = {
     id: string;
@@ -124,23 +126,31 @@
       </ul>
     </nav>
 
-    <article class="skills__detail" aria-live="polite">
-      <h4>{$selected.title}</h4>
-      <p>{$selected.narrative}</p>
-      <ul class="skills__highlights">
-        {#each $selected.highlights as highlight}
-          <li>{highlight}</li>
-        {/each}
-      </ul>
-      <dl>
-        {#each $selected.stack as item}
-          <div>
-            <dt>{item.label}</dt>
-            <dd>{item.detail}</dd>
-          </div>
-        {/each}
-      </dl>
-    </article>
+    <div aria-live="polite">
+      {#key $selected.id}
+        <article
+          class="skills__detail"
+          in:fly={{ y: 12, duration: 220, easing: cubicOut }}
+          out:fade={{ duration: 140 }}
+        >
+          <h4>{$selected.title}</h4>
+          <p>{$selected.narrative}</p>
+          <ul class="skills__highlights">
+            {#each $selected.highlights as highlight}
+              <li>{highlight}</li>
+            {/each}
+          </ul>
+          <dl>
+            {#each $selected.stack as item}
+              <div>
+                <dt>{item.label}</dt>
+                <dd>{item.detail}</dd>
+              </div>
+            {/each}
+          </dl>
+        </article>
+      {/key}
+    </div>
   </div>
 </section>
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -23,3 +23,29 @@ if (typeof window !== 'undefined' && !('matchMedia' in window)) {
     })),
   });
 }
+
+if (typeof Element !== 'undefined' && !Element.prototype.animate) {
+  Element.prototype.animate = ((
+    keyframes?: Keyframe[] | PropertyIndexedKeyframes,
+    options?: number | KeyframeAnimationOptions,
+  ) => {
+    void keyframes;
+    void options;
+
+    const animation: Partial<Animation> = {
+      cancel: () => {},
+      commitStyles: () => {},
+      finished: Promise.resolve() as unknown as Promise<Animation>,
+      onfinish: null,
+      pause: () => {},
+      play: () => {},
+      reverse: () => {},
+      updatePlaybackRate: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    };
+
+    return animation as Animation;
+  }) as typeof Element.prototype.animate;
+}


### PR DESCRIPTION
## Summary
- add a keyed fly/fade transition to the ApplicationSkills detail panel for smoother tab changes
- polyfill Element.prototype.animate in the Vitest setup so transitions run in the test environment

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2f4ba007083338f6e43de83b486db