### PR TITLE
style: reorganize insights bento grid layout

### DIFF
--- a/src/components/home/InsightsSection.astro
+++ b/src/components/home/InsightsSection.astro
@@ -417,15 +417,28 @@ import SequenceWorkbench from '../demos/SequenceWorkbench.svelte';
 
   @media (min-width: 960px) {
     .insights__grid {
-      grid-template-columns: repeat(12, 1fr);
+      grid-template-columns: repeat(12, minmax(0, 1fr));
+      grid-auto-rows: minmax(320px, auto);
+      align-items: stretch;
+    }
+
+    .insight-card {
+      height: 100%;
     }
 
     .insight-card--demo {
-      grid-column: span 12;
+      grid-column: span 8;
+      grid-row: span 2;
+      width: 100%;
+      margin-inline: 0;
     }
 
     .insight-card--upcoming {
-      grid-column: span 6;
+      grid-column: 9 / -1;
+    }
+
+    .insight-card--upcoming:last-child {
+      grid-row: 2;
     }
   }
 </style>


### PR DESCRIPTION
## Summary
- reconfigure the insights section bento grid to use a 12-column layout that maximizes horizontal space
- let the live demo span two rows while stacking the upcoming cards in the right-hand column with full-height tiles

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build
- pnpm preview --host 0.0.0.0 --port 4321

------
https://chatgpt.com/codex/tasks/task_e_68d2fe14f7c88333874c9798f78fdd91