### PR TITLE
feat: reorganize insights bento grid

### DIFF
--- a/src/components/home/InsightsSection.astro
+++ b/src/components/home/InsightsSection.astro
@@ -13,7 +13,10 @@ import SequenceWorkbench from '../demos/SequenceWorkbench.svelte';
     <article class="insight-card insight-card--demo" data-reveal>
       <SequenceWorkbench client:visible />
     </article>
-    <article class="insight-card insight-card--upcoming" data-reveal>
+    <article
+      class="insight-card insight-card--upcoming insight-card--homelab"
+      data-reveal
+    >
       <header class="insight-card__header">
         <span class="insight-card__badge insight-card__badge--soon"
           >Coming Soon</span
@@ -37,7 +40,10 @@ import SequenceWorkbench from '../demos/SequenceWorkbench.svelte';
         </div>
       </div>
     </article>
-    <article class="insight-card insight-card--upcoming" data-reveal>
+    <article
+      class="insight-card insight-card--upcoming insight-card--nextflow"
+      data-reveal
+    >
       <header class="insight-card__header">
         <span class="insight-card__badge insight-card__badge--soon"
           >Coming Soon</span
@@ -93,6 +99,7 @@ import SequenceWorkbench from '../demos/SequenceWorkbench.svelte';
     background: color-mix(in oklab, var(--color-surface) 85%, transparent 15%);
     display: grid;
     gap: var(--space-sm);
+    height: 100%;
   }
 
   .insight-card h3 {
@@ -139,6 +146,7 @@ import SequenceWorkbench from '../demos/SequenceWorkbench.svelte';
 
   .insight-card--upcoming {
     position: relative;
+    align-content: start;
   }
 
   .insight-card--upcoming p {
@@ -417,15 +425,26 @@ import SequenceWorkbench from '../demos/SequenceWorkbench.svelte';
 
   @media (min-width: 960px) {
     .insights__grid {
-      grid-template-columns: repeat(12, 1fr);
+      grid-template-columns: repeat(12, minmax(0, 1fr));
+      grid-auto-rows: minmax(20rem, auto);
+      grid-auto-flow: dense;
     }
 
     .insight-card--demo {
-      grid-column: span 12;
+      width: 100%;
+      margin-inline: 0;
+      grid-column: span 7;
+      grid-row: span 2;
     }
 
-    .insight-card--upcoming {
-      grid-column: span 6;
+    .insight-card--homelab {
+      grid-column: 8 / span 5;
+      grid-row: 1;
+    }
+
+    .insight-card--nextflow {
+      grid-column: 8 / span 5;
+      grid-row: 2;
     }
   }
 </style>


### PR DESCRIPTION
## Summary
- repositioned the Insights section bento layout to span the live demo across two rows with upcoming cards stacked alongside it
- ensured cards stretch within their grid areas for a balanced layout

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2fe14f7c88333874c9798f78fdd91