### PR TITLE
fix: stabilize skills panel animation

### DIFF
--- a/src/components/skills/ApplicationSkills.svelte
+++ b/src/components/skills/ApplicationSkills.svelte
@@ -126,7 +126,7 @@
       </ul>
     </nav>
 
-    <div aria-live="polite">
+    <div class="skills__panel" aria-live="polite">
       {#key $selected.id}
         <article
           class="skills__detail"
@@ -225,6 +225,15 @@
     border-color: var(--color-primary);
     color: var(--color-text);
     background: color-mix(in oklab, var(--color-primary) 20%, var(--color-surface));
+  }
+
+  .skills__panel {
+    position: relative;
+    display: grid;
+  }
+
+  .skills__panel > * {
+    grid-area: 1 / 1 / -1 / -1;
   }
 
   .skills__detail {


### PR DESCRIPTION
## Summary
- overlay the ApplicationSkills detail panel to prevent stacked elements during transitions
- keep the existing fly/fade animation so category switches feel smooth without jitter

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build
- pnpm preview --host

------
https://chatgpt.com/codex/tasks/task_e_68d2fff7b4b48333a47b99652e4dae6a