### PR TITLE
fix: update navigation label for interactive lab

### DIFF
--- a/src/components/home/HomeHeader.astro
+++ b/src/components/home/HomeHeader.astro
@@ -7,7 +7,7 @@ const navLinks = [
   { label: 'Projects', href: '#projects' },
   { label: 'Skills', href: '#skills' },
   { label: 'Experience', href: '#experience' },
-  { label: 'Insights', href: '#insights' },
+  { label: 'Interactive Lab', href: '#insights' },
   { label: 'Contact', href: '#contact' },
 ];
 ---

--- a/tests/e2e/components.spec.ts
+++ b/tests/e2e/components.spec.ts
@@ -29,7 +29,7 @@ test.describe('Home page experience', () => {
       'Projects',
       'Skills',
       'Experience',
-      'Insights',
+      'Interactive Lab',
       'Contact',
     ];
 


### PR DESCRIPTION
## Summary
- update the home header navigation link label to "Interactive Lab"
- align the Playwright navigation label expectations with the new copy

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d317b206508333b592530f4518ef74