### PR TITLE
feat: reorder homepage sections

### DIFF
--- a/src/components/home/HeroSection.astro
+++ b/src/components/home/HeroSection.astro
@@ -27,7 +27,7 @@ const { stats } = Astro.props as Props;
       </p>
       <div class="hero__actions">
         <a class="hero__cta" href="#contact">Collaborate</a>
-        <a class="hero__scroll" href="#projects">
+        <a class="hero__scroll" href="#experience">
           <span>See more</span>
           <svg aria-hidden="true" viewBox="0 0 24 24" role="presentation">
             <path

--- a/src/components/home/HomeHeader.astro
+++ b/src/components/home/HomeHeader.astro
@@ -4,10 +4,10 @@ import ThemeToggle from '../ui/ThemeToggle.svelte';
 
 const navLinks = [
   { label: 'Overview', href: '#hero' },
-  { label: 'Projects', href: '#projects' },
-  { label: 'Skills', href: '#skills' },
   { label: 'Experience', href: '#experience' },
+  { label: 'Projects', href: '#projects' },
   { label: 'Interactive Lab', href: '#insights' },
+  { label: 'Skills', href: '#skills' },
   { label: 'Contact', href: '#contact' },
 ];
 ---

--- a/src/components/home/InsightsSection.astro
+++ b/src/components/home/InsightsSection.astro
@@ -5,9 +5,9 @@ import SequenceWorkbench from '../demos/SequenceWorkbench.svelte';
 
 <section class="section section--insights" id="insights" data-reveal>
   <SectionHeader
-    overline="Interactive Lab"
-    title="Live tools and sandboxes for genomic computing"
-    description="Try it yourself—from sequence analysis to cluster deployments."
+    overline="Live tools and sandboxes for genomic computing"
+    title="Interactive Lab"
+    description="Operating principles for reproducible, scalable science. Try it yourself—from sequence analysis to cluster deployments."
   />
   <div class="u-container insights__grid">
     <article class="insight-card insight-card--demo" data-reveal>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,10 +2,10 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import HomeHeader from '../components/home/HomeHeader.astro';
 import HeroSection from '../components/home/HeroSection.astro';
-import ProjectsSection from '../components/home/ProjectsSection.astro';
-import SkillsSection from '../components/home/SkillsSection.astro';
 import ExperienceSection from '../components/home/ExperienceSection.astro';
+import ProjectsSection from '../components/home/ProjectsSection.astro';
 import InsightsSection from '../components/home/InsightsSection.astro';
+import SkillsSection from '../components/home/SkillsSection.astro';
 import ContactSection from '../components/home/ContactSection.astro';
 import RevealInitializer from '../components/util/RevealInitializer.svelte';
 import {
@@ -22,10 +22,10 @@ import '../styles/pages/home.css';
 
   <main>
     <HeroSection stats={heroStats} />
-    <ProjectsSection projects={projects} />
-    <SkillsSection />
     <ExperienceSection experiences={experiences} />
+    <ProjectsSection projects={projects} />
     <InsightsSection />
+    <SkillsSection />
     <ContactSection channels={contactChannels} />
   </main>
   <RevealInitializer client:load />

--- a/tests/e2e/components.spec.ts
+++ b/tests/e2e/components.spec.ts
@@ -26,10 +26,10 @@ test.describe('Home page experience', () => {
 
     const navLabels = [
       'Overview',
-      'Projects',
-      'Skills',
       'Experience',
+      'Projects',
       'Interactive Lab',
+      'Skills',
       'Contact',
     ];
 
@@ -41,7 +41,7 @@ test.describe('Home page experience', () => {
     await expect(page.getByRole('link', { name: 'Collaborate' })).toBeVisible();
     const seeMoreLink = page.getByRole('link', { name: 'See more' });
     await expect(seeMoreLink).toBeVisible();
-    await expect(seeMoreLink).toHaveAttribute('href', '#projects');
+    await expect(seeMoreLink).toHaveAttribute('href', '#experience');
 
     await expect(page.locator('.hero__metric')).toHaveCount(3);
   });
@@ -121,9 +121,7 @@ test.describe('Home page experience', () => {
     await insights.scrollIntoViewIfNeeded();
     await expect(insights).toBeVisible();
     await expect(
-      page.getByRole('heading', {
-        name: 'Live tools and sandboxes for genomic computing',
-      }),
+      page.getByRole('heading', { name: 'Interactive Lab' }),
     ).toBeVisible();
 
     const contact = page.locator('#contact');


### PR DESCRIPTION
## Summary
- reorder the home page sections to surface experience, projects, and the interactive lab earlier
- align the hero scroll link and primary navigation with the new visitor flow
- refresh the interactive lab header copy and update accompanying e2e expectations

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d31d7703448333bd73ee9009f8e66a