### PR TITLE
refactor: extract reusable ProjectCard helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "typescript": "^5.9.2"
   },
   "devDependencies": {
+    "@astrojs/compiler": "^2.13.0",
     "@axe-core/playwright": "^4.10.2",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
         specifier: ^5.9.2
         version: 5.9.2
     devDependencies:
+      '@astrojs/compiler':
+        specifier: ^2.13.0
+        version: 2.13.0
       '@axe-core/playwright':
         specifier: ^4.10.2
         version: 4.10.2(playwright-core@1.55.1)
@@ -156,9 +159,6 @@ packages:
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
-
-  '@astrojs/compiler@2.12.2':
-    resolution: {integrity: sha512-w2zfvhjNCkNMmMMOn5b0J8+OmUaBL1o40ipMvqcG6NRpdC+lKxmTi48DT8Xw0SzJ3AfmeFLB45zXZXtmbsjcgw==}
 
   '@astrojs/compiler@2.13.0':
     resolution: {integrity: sha512-mqVORhUJViA28fwHYaWmsXSzLO9osbdZ5ImUfxBarqsYdMlPbqAqGJCxsNzvppp1BEzc1mJNjOVvQqeDN8Vspw==}
@@ -5445,8 +5445,6 @@ snapshots:
       - prettier
       - prettier-plugin-astro
 
-  '@astrojs/compiler@2.12.2': {}
-
   '@astrojs/compiler@2.13.0': {}
 
   '@astrojs/internal-helpers@0.7.3': {}
@@ -7270,10 +7268,10 @@ snapshots:
 
   astro-eslint-parser@1.2.2:
     dependencies:
-      '@astrojs/compiler': 2.12.2
+      '@astrojs/compiler': 2.13.0
       '@typescript-eslint/scope-manager': 8.43.0
       '@typescript-eslint/types': 8.43.0
-      astrojs-compiler-sync: 1.1.1(@astrojs/compiler@2.12.2)
+      astrojs-compiler-sync: 1.1.1(@astrojs/compiler@2.13.0)
       debug: 4.4.1
       entities: 6.0.1
       eslint-scope: 8.4.0
@@ -7387,9 +7385,9 @@ snapshots:
       - uploadthing
       - yaml
 
-  astrojs-compiler-sync@1.1.1(@astrojs/compiler@2.12.2):
+  astrojs-compiler-sync@1.1.1(@astrojs/compiler@2.13.0):
     dependencies:
-      '@astrojs/compiler': 2.12.2
+      '@astrojs/compiler': 2.13.0
       synckit: 0.11.11
 
   async-function@1.0.0: {}
@@ -9936,7 +9934,7 @@ snapshots:
 
   prettier-plugin-astro@0.14.1:
     dependencies:
-      '@astrojs/compiler': 2.12.2
+      '@astrojs/compiler': 2.13.0
       prettier: 3.6.2
       sass-formatter: 0.7.9
 

--- a/src/components/home/ProjectCard.astro
+++ b/src/components/home/ProjectCard.astro
@@ -1,6 +1,7 @@
 ---
 import type { Project } from '../../content/home';
-import ProjectDetailList from './ProjectDetailList.astro';
+import ProjectCardHeader from './ProjectCardHeader.astro';
+import ProjectDetailGroup from './ProjectDetailGroup.astro';
 import { getProjectDetails } from './projectDetails';
 
 interface Props {
@@ -17,10 +18,7 @@ const details = getProjectDetails(project);
       case 'wide':
         return (
           <article class="project-card project-card--wide u-glass" data-reveal>
-            <header>
-              <h3>{project.title}</h3>
-              <p>{project.summary}</p>
-            </header>
+            <ProjectCardHeader project={project} />
             <div class="project-card__content">
               <div>
                 <h4>Problem</h4>
@@ -30,11 +28,18 @@ const details = getProjectDetails(project);
                 <h4>Solution</h4>
                 <p>{project.solution}</p>
               </div>
-              <ProjectDetailList detail={details.stack} wrapper="div" />
+              <ProjectDetailGroup
+                details={details}
+                keys={['stack']}
+                wrapper="div"
+              />
             </div>
             <div class="project-card__footer">
-              <ProjectDetailList detail={details.results} wrapper="div" />
-              <ProjectDetailList detail={details.challenges} wrapper="div" />
+              <ProjectDetailGroup
+                details={details}
+                keys={['results', 'challenges']}
+                wrapper="div"
+              />
             </div>
             {project.link && (
               <a class="project-card__link" href={project.link}>
@@ -46,10 +51,7 @@ const details = getProjectDetails(project);
       case 'standard':
         return (
           <article class="project-card project-card--standard" data-reveal>
-            <header>
-              <h3>{project.title}</h3>
-              <p>{project.summary}</p>
-            </header>
+            <ProjectCardHeader project={project} />
             <dl>
               <div>
                 <dt>Problem</dt>
@@ -61,19 +63,17 @@ const details = getProjectDetails(project);
               </div>
             </dl>
             <div class="project-card__meta">
-              <ProjectDetailList detail={details.stack} />
-              <ProjectDetailList detail={details.results} />
-              <ProjectDetailList detail={details.challenges} />
+              <ProjectDetailGroup
+                details={details}
+                keys={['stack', 'results', 'challenges']}
+              />
             </div>
           </article>
         );
       case 'tall':
         return (
           <article class="project-card project-card--tall" data-reveal>
-            <header>
-              <h3>{project.title}</h3>
-              <p>{project.summary}</p>
-            </header>
+            <ProjectCardHeader project={project} />
             <div class="project-card__meta">
               <h4>Problem</h4>
               <p>{project.problem}</p>
@@ -81,9 +81,10 @@ const details = getProjectDetails(project);
               <p>{project.solution}</p>
             </div>
             <div class="project-card__meta">
-              <ProjectDetailList detail={details.stack} />
-              <ProjectDetailList detail={details.results} />
-              <ProjectDetailList detail={details.challenges} />
+              <ProjectDetailGroup
+                details={details}
+                keys={['stack', 'results', 'challenges']}
+              />
             </div>
           </article>
         );

--- a/src/components/home/ProjectCardHeader.astro
+++ b/src/components/home/ProjectCardHeader.astro
@@ -1,0 +1,14 @@
+---
+import type { Project } from '../../content/home';
+
+interface Props {
+  project: Project;
+}
+
+const { project } = Astro.props as Props;
+---
+
+<header>
+  <h3>{project.title}</h3>
+  <p>{project.summary}</p>
+</header>

--- a/src/components/home/ProjectDetailGroup.astro
+++ b/src/components/home/ProjectDetailGroup.astro
@@ -1,0 +1,18 @@
+---
+import ProjectDetailList from './ProjectDetailList.astro';
+import type { ProjectDetailMap } from './projectDetails';
+
+interface Props {
+  details: ProjectDetailMap;
+  keys: (keyof ProjectDetailMap)[];
+  wrapper?: 'div';
+}
+
+const { details, keys, wrapper } = Astro.props as Props;
+---
+
+{
+  keys.map((key) => (
+    <ProjectDetailList detail={details[key]} wrapper={wrapper} />
+  ))
+}

--- a/tests/types.d.ts
+++ b/tests/types.d.ts
@@ -1,0 +1,4 @@
+declare module '*.astro' {
+  const component: import('astro/runtime/server/render/index.js').AstroComponentFactory;
+  export default component;
+}

--- a/tests/unit/components/home/ProjectCard.spec.ts
+++ b/tests/unit/components/home/ProjectCard.spec.ts
@@ -1,0 +1,192 @@
+import type { AstroComponentFactory } from 'astro/runtime/server/render/index.js';
+import { renderToString } from 'astro/runtime/server/render/index.js';
+import { describe, expect, it } from 'vitest';
+
+import ProjectCard from '../../../../src/components/home/ProjectCard.astro';
+import type { Project } from '../../../../src/content/home';
+
+const createProject = (
+  layout: Project['layout'],
+  overrides: Partial<Project> = {},
+): Project => ({
+  title: 'Test Project',
+  summary: 'Testing summary copy',
+  problem: 'A repeatable problem statement for validation.',
+  solution: 'A measured solution capturing implementation details.',
+  stack: ['Astro', 'TypeScript'],
+  results: ['Improved rendering flow'],
+  challenges: ['Ensuring helper reuse across layouts'],
+  layout,
+  ...overrides,
+});
+
+type AstroSSRResult = Parameters<typeof renderToString>[0];
+
+const createResponse = (): AstroSSRResult['response'] => {
+  const headers = new Headers();
+  return {
+    status: 200,
+    statusText: 'OK',
+    get headers() {
+      return headers;
+    },
+    set headers(_) {
+      throw new Error(
+        'Reassigning response headers is not supported in tests.',
+      );
+    },
+  };
+};
+
+const createTestResult = (): AstroSSRResult => {
+  type CreateAstroParams = Parameters<AstroSSRResult['createAstro']>;
+  const createAstro: AstroSSRResult['createAstro'] = (
+    astroGlobal: CreateAstroParams[0],
+    props: CreateAstroParams[1],
+    slots: CreateAstroParams[2],
+  ) =>
+    ({
+      ...(astroGlobal as unknown as Record<string, unknown>),
+      props,
+      slots: slots ?? ({} as CreateAstroParams[2]),
+    }) as ReturnType<AstroSSRResult['createAstro']>;
+
+  return {
+    base: '/',
+    userAssetsBase: undefined,
+    cancelled: false,
+    styles: new Set(),
+    scripts: new Set(),
+    links: new Set(),
+    componentMetadata: new Map(),
+    inlinedScripts: new Map(),
+    params: {},
+    resolve: async (specifier: string) => specifier,
+    response: createResponse(),
+    request: new Request('http://example.com/'),
+    renderers: [],
+    clientDirectives: new Map(),
+    compressHTML: false,
+    partial: false,
+    pathname: '/',
+    cookies: undefined,
+    serverIslandNameMap: new Map(),
+    trailingSlash: 'ignore',
+    key: Promise.resolve({} as CryptoKey),
+    _metadata: {
+      hasHydrationScript: false,
+      rendererSpecificHydrationScripts: new Set(),
+      hasRenderedHead: false,
+      renderedScripts: new Set(),
+      hasDirectives: new Set(),
+      hasRenderedServerIslandRuntime: false,
+      headInTree: false,
+      extraHead: [],
+      extraStyleHashes: [],
+      extraScriptHashes: [],
+      propagators: new Set(),
+    },
+    cspDestination: 'meta',
+    shouldInjectCspMetaTags: false,
+    cspAlgorithm: 'SHA-256',
+    scriptHashes: [],
+    scriptResources: [],
+    styleHashes: [],
+    styleResources: [],
+    directives: [],
+    isStrictDynamic: false,
+    actionResult: undefined,
+    createAstro,
+  };
+};
+
+const renderProjectCard = async (project: Project) => {
+  const result = createTestResult();
+  const html = await renderToString(
+    result,
+    ProjectCard as unknown as AstroComponentFactory,
+    { project },
+    {},
+  );
+
+  if (typeof html !== 'string') {
+    throw new Error('ProjectCard did not render static HTML.');
+  }
+
+  document.body.innerHTML = html;
+  return document.body.querySelector('article.project-card');
+};
+
+describe('ProjectCard', () => {
+  it('renders the wide layout with grouped details and link', async () => {
+    const project = createProject('wide', { link: 'https://example.com' });
+    const article = await renderProjectCard(project);
+
+    expect(article).not.toBeNull();
+    expect(article).toHaveClass('project-card--wide');
+
+    const header = article?.querySelector('header');
+    expect(header?.querySelector('h3')?.textContent).toBe(project.title);
+    expect(header?.querySelector('p')?.textContent).toBe(project.summary);
+
+    const contentHeadings = Array.from(
+      article?.querySelectorAll('.project-card__content h4') ?? [],
+    ).map((heading) => heading.textContent);
+    expect(contentHeadings).toEqual(['Problem', 'Solution', 'Stack']);
+
+    const footerHeadings = Array.from(
+      article?.querySelectorAll('.project-card__footer h4') ?? [],
+    ).map((heading) => heading.textContent);
+    expect(footerHeadings).toEqual(['Results', 'Technical Challenges']);
+
+    const link = article?.querySelector('.project-card__link');
+    expect(link).toHaveAttribute('href', project.link);
+  });
+
+  it('renders the standard layout definition list with detail headings', async () => {
+    const project = createProject('standard');
+    const article = await renderProjectCard(project);
+
+    expect(article).not.toBeNull();
+    expect(article).toHaveClass('project-card--standard');
+
+    const terms = Array.from(article?.querySelectorAll('dl dt') ?? []).map(
+      (term) => term.textContent,
+    );
+    expect(terms).toEqual(['Problem', 'Solution']);
+
+    const detailHeadings = Array.from(
+      article?.querySelectorAll('.project-card__meta h4') ?? [],
+    ).map((heading) => heading.textContent);
+    expect(detailHeadings).toEqual([
+      'Stack',
+      'Results',
+      'Technical Challenges',
+    ]);
+  });
+
+  it('renders the tall layout with separate narrative and detail sections', async () => {
+    const project = createProject('tall');
+    const article = await renderProjectCard(project);
+
+    expect(article).not.toBeNull();
+    expect(article).toHaveClass('project-card--tall');
+
+    const metaSections = article?.querySelectorAll('.project-card__meta');
+    expect(metaSections?.length).toBe(2);
+
+    const narrativeHeadings = Array.from(
+      metaSections?.[0]?.querySelectorAll('h4') ?? [],
+    ).map((heading) => heading.textContent);
+    expect(narrativeHeadings).toEqual(['Problem', 'Solution']);
+
+    const detailHeadings = Array.from(
+      metaSections?.[1]?.querySelectorAll('h4') ?? [],
+    ).map((heading) => heading.textContent);
+    expect(detailHeadings).toEqual([
+      'Stack',
+      'Results',
+      'Technical Challenges',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- extract shared header and detail rendering into ProjectCardHeader and ProjectDetailGroup components
- update vitest config and type declarations so Astro components compile in unit tests
- add ProjectCard unit coverage across wide, standard, and tall layouts

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build
- pnpm preview --host

------
https://chatgpt.com/codex/tasks/task_e_68d321cabdd08333bfa3453adca2a76c