### PR TITLE
fix: handle missing requestAnimationFrame in initReveal

### DIFF
--- a/src/scripts/initReveal.ts
+++ b/src/scripts/initReveal.ts
@@ -82,9 +82,15 @@ export const initReveal = ({
 
     revealNodes.forEach(revealIfVisible);
 
-    requestAnimationFrame(() => {
+    const setActiveState = () => {
       rootElement.dataset.revealState = 'active';
-    });
+    };
+
+    if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(setActiveState);
+    } else {
+      setActiveState();
+    }
   };
 
   if (window.scrollY > 0) {

--- a/tests/unit/scripts/initReveal.test.ts
+++ b/tests/unit/scripts/initReveal.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { initReveal } from '../../../src/scripts/initReveal';
+
+const windowAny = window as any;
+const originalRAF = windowAny.requestAnimationFrame;
+const originalIntersectionObserver = windowAny.IntersectionObserver;
+const originalMatchMedia = windowAny.matchMedia;
+
+class MockIntersectionObserver {
+  private callback: IntersectionObserverCallback;
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+  }
+
+  observe = (element: Element) => {
+    this.callback(
+      [
+        {
+          isIntersecting: true,
+          target: element,
+        } as IntersectionObserverEntry,
+      ],
+      this as unknown as IntersectionObserver,
+    );
+  };
+  unobserve = () => {};
+  disconnect = () => {};
+  takeRecords = () => [] as IntersectionObserverEntry[];
+}
+
+describe('initReveal', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <main>
+        <section data-reveal></section>
+        <section data-reveal></section>
+      </main>
+    `;
+    document.documentElement.removeAttribute('data-reveal-state');
+
+    windowAny.requestAnimationFrame = undefined;
+    windowAny.IntersectionObserver =
+      MockIntersectionObserver as unknown as typeof IntersectionObserver;
+    windowAny.matchMedia = () => ({
+      matches: false,
+      addEventListener() {},
+      removeEventListener() {},
+      addListener() {},
+      removeListener() {},
+      dispatchEvent() {
+        return false;
+      },
+      onchange: null,
+      media: '',
+    });
+  });
+
+  afterEach(() => {
+    windowAny.requestAnimationFrame = originalRAF;
+
+    if (originalIntersectionObserver) {
+      windowAny.IntersectionObserver = originalIntersectionObserver;
+    } else {
+      delete windowAny.IntersectionObserver;
+    }
+
+    if (originalMatchMedia) {
+      windowAny.matchMedia = originalMatchMedia;
+    } else {
+      delete windowAny.matchMedia;
+    }
+
+    document.body.innerHTML = '';
+    document.documentElement.removeAttribute('data-reveal-state');
+  });
+
+  it('marks reveal nodes as active without requestAnimationFrame', () => {
+    expect(() => initReveal()).not.toThrow();
+
+    window.dispatchEvent(new Event('scroll'));
+
+    expect(document.documentElement.dataset.revealState).toBe('active');
+
+    const revealNodes = Array.from(document.querySelectorAll('[data-reveal]'));
+    expect(revealNodes).toHaveLength(2);
+
+    revealNodes.forEach((node) => {
+      expect(node.classList.contains('is-revealed')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- guard the reveal initialization to fall back when `requestAnimationFrame` is unavailable
- add a unit test that simulates a missing `requestAnimationFrame` and verifies the reveal activation

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d321c550ec8333a932891bc7652844