### PR TITLE
fix: preserve caret after sequence sanitization

### DIFF
--- a/src/components/demos/SequenceWorkbench.svelte
+++ b/src/components/demos/SequenceWorkbench.svelte
@@ -27,20 +27,53 @@
     }
   };
 
+  const sanitizeSequenceWithSelection = (
+    value: string,
+    selectionStart: number,
+    selectionEnd: number,
+  ) => {
+    let sanitizedValue = '';
+    let sanitizedStart = 0;
+    let sanitizedEnd = 0;
+
+    const clampedStart = Math.max(0, Math.min(selectionStart, value.length));
+    const clampedEnd = Math.max(0, Math.min(selectionEnd, value.length));
+
+    for (let index = 0; index < value.length; index += 1) {
+      const character = value[index];
+
+      if (!baseKeyPattern.test(character)) continue;
+
+      sanitizedValue += character.toUpperCase();
+
+      if (index < clampedStart) sanitizedStart += 1;
+      if (index < clampedEnd) sanitizedEnd += 1;
+    }
+
+    const sanitizedLength = sanitizedValue.length;
+
+    return {
+      value: sanitizedValue,
+      selectionStart: Math.min(sanitizedStart, sanitizedLength),
+      selectionEnd: Math.min(sanitizedEnd, sanitizedLength),
+    };
+  };
+
   const handleSequenceInput = (event: Event) => {
     const target = event.currentTarget as HTMLTextAreaElement | null;
     if (!target) return;
 
     const rawValue = target.value;
-    const sanitizedValue = cleanSequence(rawValue);
-
     const selectionStart = target.selectionStart ?? rawValue.length;
     const selectionEnd = target.selectionEnd ?? rawValue.length;
 
-    if (rawValue !== sanitizedValue) {
-      const sanitizedStart = cleanSequence(rawValue.slice(0, selectionStart)).length;
-      const sanitizedEnd = cleanSequence(rawValue.slice(0, selectionEnd)).length;
+    const {
+      value: sanitizedValue,
+      selectionStart: sanitizedStart,
+      selectionEnd: sanitizedEnd,
+    } = sanitizeSequenceWithSelection(rawValue, selectionStart, selectionEnd);
 
+    if (rawValue !== sanitizedValue) {
       target.value = sanitizedValue;
 
       const applySelection = () => target.setSelectionRange(sanitizedStart, sanitizedEnd);

--- a/tests/unit/components/demos/SequenceWorkbench.spec.ts
+++ b/tests/unit/components/demos/SequenceWorkbench.spec.ts
@@ -87,4 +87,33 @@ describe('SequenceWorkbench', () => {
       expect(heading.nextElementSibling?.textContent).toBe('');
     });
   });
+
+  it('keeps caret aligned after filtering invalid middle characters', async () => {
+    render(SequenceWorkbench);
+    const textarea = screen.getByPlaceholderText(
+      'Paste genomic sequence',
+    ) as HTMLTextAreaElement;
+
+    textarea.value = 'ATGC';
+    textarea.selectionStart = 4;
+    textarea.selectionEnd = 4;
+    await fireEvent.input(textarea);
+    await tick();
+
+    textarea.selectionStart = 2;
+    textarea.selectionEnd = 2;
+
+    const rawValueWithInvalid = 'ATxGC';
+    textarea.value = rawValueWithInvalid;
+    textarea.selectionStart = 3;
+    textarea.selectionEnd = 3;
+    await fireEvent.input(textarea);
+    await tick();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(textarea.value).toBe('ATGC');
+    expect(textarea.selectionStart).toBe(2);
+    expect(textarea.selectionEnd).toBe(2);
+  });
 });


### PR DESCRIPTION
## Summary
- add a single-pass sanitizer that also maps selection offsets for the sequence textarea
- update the input handler to reuse the helper so caret placement stays consistent when invalid bases are filtered
- cover mid-string invalid edits with a focused SequenceWorkbench unit test

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d32192c26c83338d4ee94851638ce6