### PR TITLE
refactor: add mobile nav init cleanup

### DIFF
--- a/src/components/scripts/MobileNavInitializer.svelte
+++ b/src/components/scripts/MobileNavInitializer.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
 
   import initMobileNav from '../../scripts/initMobileNav';
 
+  let cleanup: ReturnType<typeof initMobileNav>;
+
   onMount(() => {
-    initMobileNav();
+    cleanup = initMobileNav();
+  });
+
+  onDestroy(() => {
+    cleanup?.();
+    cleanup = undefined;
   });
 </script>

--- a/tests/unit/scripts/initMobileNav.test.ts
+++ b/tests/unit/scripts/initMobileNav.test.ts
@@ -1,0 +1,59 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+vi.mock('../../../src/scripts/setupMobileNav', () => ({
+  setupMobileNav: vi.fn(() => vi.fn()),
+}));
+
+type InitMobileNav =
+  (typeof import('../../../src/scripts/initMobileNav'))['default'];
+
+let initMobileNav: InitMobileNav;
+
+beforeAll(async () => {
+  ({ default: initMobileNav } = await import(
+    '../../../src/scripts/initMobileNav'
+  ));
+});
+
+describe('initMobileNav', () => {
+  let addEventListenerSpy: ReturnType<typeof vi.spyOn>;
+  let removeEventListenerSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    addEventListenerSpy = vi.spyOn(document, 'addEventListener');
+    removeEventListenerSpy = vi.spyOn(document, 'removeEventListener');
+  });
+
+  afterEach(() => {
+    addEventListenerSpy.mockRestore();
+    removeEventListenerSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it('removes the astro:page-load listener when cleaned up', () => {
+    const cleanup = initMobileNav();
+
+    expect(cleanup).toBeTypeOf('function');
+
+    const pageLoadListener = addEventListenerSpy.mock.calls.find(
+      ([eventName]) => eventName === 'astro:page-load',
+    )?.[1] as EventListener | undefined;
+
+    expect(pageLoadListener).toBeTypeOf('function');
+
+    cleanup();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'astro:page-load',
+      pageLoadListener,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- refactor mobile nav initialization to keep track of scheduled work and expose a cleanup function
- ensure the Svelte mobile nav initializer releases listeners when the component unmounts
- cover the cleanup behaviour with a focused unit test for initMobileNav

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build
- pnpm preview --host (manually stopped)


------
https://chatgpt.com/codex/tasks/task_e_68d321b9afd883338c695bfc5e70d212