### PR TITLE
feat: add slide animation to skills tabs

### DIFF
--- a/tests/unit/components/skills/ApplicationSkills.spec.ts
+++ b/tests/unit/components/skills/ApplicationSkills.spec.ts
@@ -32,12 +32,12 @@ describe('ApplicationSkills', () => {
     expect(infrastructureButton).toHaveClass('selected');
     expect(scientificButton).not.toHaveClass('selected');
     expect(
-      screen.getByText(
+      await screen.findByText(
         /Hybrid infrastructure spanning Azure Container Apps, on-prem Proxmox virtualization, and privately managed Kubernetes automation keeps sequencing pipelines resilient/i,
       ),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
+      await screen.findByText(
         /Managed hybrid infrastructure spanning Azure Container Apps and on-premises Proxmox virtualization/i,
       ),
     ).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- implement slide-out, cursor blink, and slide-in animations for skill category changes with reduced-motion support
- show a terminal-style cursor placeholder between transitions and mark active tab state for accessibility
- update the ApplicationSkills unit test to await the asynchronous animation sequence

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d34c12f1ac8333884290a6f2493ce5