### PR TITLE
fix: simplify focus area backgrounds

### DIFF
--- a/src/components/home/ContactSection.astro
+++ b/src/components/home/ContactSection.astro
@@ -151,13 +151,8 @@ const { channels } = Astro.props as Props;
     border-radius: var(--radius-lg);
     border: 1px solid
       color-mix(in oklab, var(--color-border) 55%, transparent 45%);
-    background: linear-gradient(
-      140deg,
-      color-mix(in oklab, var(--color-surface) 96%, transparent 4%),
-      color-mix(in oklab, var(--color-surface-strong) 90%, transparent 10%)
-    );
-    box-shadow: inset 0 1px 0
-      color-mix(in oklab, var(--color-surface) 70%, transparent 30%);
+    background: color-mix(in oklab, var(--color-surface) 92%, transparent 8%);
+    box-shadow: var(--shadow-sm);
   }
 
   .contact__focus-list strong {

--- a/types/astrojs-compiler.d.ts
+++ b/types/astrojs-compiler.d.ts
@@ -1,0 +1,16 @@
+/* eslint-disable no-unused-vars */
+declare module '@astrojs/compiler' {
+  interface TransformOptions {
+    filename?: string;
+  }
+
+  interface TransformResult {
+    code: string;
+    map?: string | null;
+  }
+
+  export const transform: (
+    source: string,
+    options?: TransformOptions,
+  ) => Promise<TransformResult>;
+}


### PR DESCRIPTION
## Summary
- replace the focus area list gradient with a flat surface tone and consistent shadow treatment
- add a lightweight type declaration for `@astrojs/compiler` so Astro checks can resolve the Vitest config import

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d34fa40dc08333b5a60ae47833f353