### PR TITLE
feat: add typing transition to application skills

### DIFF
--- a/tests/unit/components/skills/ApplicationSkills.spec.ts
+++ b/tests/unit/components/skills/ApplicationSkills.spec.ts
@@ -34,6 +34,8 @@ describe('ApplicationSkills', () => {
     expect(
       await screen.findByText(
         /Hybrid infrastructure spanning Azure Container Apps, on-prem Proxmox virtualization, and privately managed Kubernetes automation keeps sequencing pipelines resilient/i,
+        undefined,
+        { timeout: 5000 },
       ),
     ).toBeInTheDocument();
     expect(


### PR DESCRIPTION
## Summary
- replace the previous tab transition cursor with a console-style typing effect when changing application skills
- respect the reduced-motion preference by disabling the typing animation and keeping narratives readable
- update the application skills unit test to wait for the typed copy to finish rendering

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d424a585e08333ae88f28fc5af1fc9