### PR TITLE
style: center contact layout on large screens

### DIFF
--- a/src/components/home/ContactSection.astro
+++ b/src/components/home/ContactSection.astro
@@ -285,4 +285,20 @@ const { channels } = Astro.props as Props;
       align-items: start;
     }
   }
+
+  @media (min-width: 1200px) {
+    .contact {
+      grid-template-columns: repeat(2, minmax(0, auto));
+      justify-content: center;
+      column-gap: clamp(3rem, 6vw, 6rem);
+    }
+
+    .contact__intro {
+      max-width: clamp(34rem, 38vw, 44rem);
+    }
+
+    .contact-card {
+      width: clamp(26rem, 30vw, 32rem);
+    }
+  }
 </style>


### PR DESCRIPTION
## Summary
- recenter the contact section grid on very wide viewports
- let the intro copy and contact card expand using clamp-based widths

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d42522c01c833387746075406f0eb6