### PR TITLE
feat: animate application skills highlights

### DIFF
--- a/tests/unit/components/skills/ApplicationSkills.spec.ts
+++ b/tests/unit/components/skills/ApplicationSkills.spec.ts
@@ -18,8 +18,10 @@ describe('ApplicationSkills', () => {
       ),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
+      await screen.findByText(
         /Orchestrated RNA\/DNA-seq and variant calling through Nextflow Tower on AWS Batch/i,
+        undefined,
+        { timeout: 5000 },
       ),
     ).toBeInTheDocument();
 
@@ -41,6 +43,8 @@ describe('ApplicationSkills', () => {
     expect(
       await screen.findByText(
         /Managed hybrid infrastructure spanning Azure Container Apps and on-premises Proxmox virtualization/i,
+        undefined,
+        { timeout: 5000 },
       ),
     ).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- keep the Application Skills narrative static while animating the highlight bullet points with a typing effect and cursor
- ensure highlight animations reset on category changes and respects reduced motion preferences
- update the ApplicationSkills unit test to wait for the typed highlight content before asserting

## Testing
- pnpm astro check
- pnpm tsc --noEmit
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d4355b8c588333a2d994f32cf0036a