### PR TITLE
style: intensify header glassmorphism

### DIFF
--- a/src/components/home/HomeHeader.astro
+++ b/src/components/home/HomeHeader.astro
@@ -100,8 +100,8 @@ const navLinks = [
     inset-inline: 0;
     z-index: 10;
     padding-block-start: var(--safe-area-top, 0px);
-    backdrop-filter: blur(20px) saturate(140%);
-    -webkit-backdrop-filter: blur(20px) saturate(140%);
+    backdrop-filter: blur(28px) saturate(145%);
+    -webkit-backdrop-filter: blur(28px) saturate(145%);
     transition:
       background var(--duration-base) var(--ease-smooth),
       border-color var(--duration-base) var(--ease-smooth),
@@ -259,8 +259,8 @@ const navLinks = [
       background: var(--glass-panel-glow), var(--glass-panel-elevated);
       border: 1px solid var(--glass-panel-border);
       box-shadow: var(--glass-panel-shadow);
-      backdrop-filter: blur(24px) saturate(160%);
-      -webkit-backdrop-filter: blur(24px) saturate(160%);
+      backdrop-filter: blur(30px) saturate(165%);
+      -webkit-backdrop-filter: blur(30px) saturate(165%);
       opacity: 1;
       visibility: visible;
       pointer-events: auto;
@@ -314,8 +314,8 @@ const navLinks = [
       margin: 0;
       z-index: 10;
       box-shadow: var(--glass-panel-shadow);
-      backdrop-filter: blur(22px) saturate(155%);
-      -webkit-backdrop-filter: blur(22px) saturate(155%);
+      backdrop-filter: blur(28px) saturate(160%);
+      -webkit-backdrop-filter: blur(28px) saturate(160%);
     }
 
     .site-nav__toggle:hover,


### PR DESCRIPTION
## Summary
- intensify the glassmorphic blur and saturation on the sticky header for a clearer frosted effect
- align the mobile navigation panel and toggle button blur with the updated desktop styling

## Testing
- pnpm build
- pnpm preview --host

------
https://chatgpt.com/codex/tasks/task_e_68db067587648333a0e7ec8a9d0ea631