### PR TITLE
fix: prevent skills panel stretching

### DIFF
--- a/src/components/skills/ApplicationSkills.svelte
+++ b/src/components/skills/ApplicationSkills.svelte
@@ -279,6 +279,7 @@
   .skills__panel {
     position: relative;
     display: grid;
+    align-items: start;
     overflow: hidden;
     transition: height var(--duration-slow) var(--ease-smooth);
   }


### PR DESCRIPTION
## Summary
- prevent the application skills panel grid from stretching its content so height measurements can shrink correctly

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68db073acba8833399f99641c0f82f9c