### PR TITLE
chore: update hero messaging to data platforms

### DIFF
--- a/src/components/home/HeroSection.astro
+++ b/src/components/home/HeroSection.astro
@@ -15,11 +15,11 @@ const { stats } = Astro.props as Props;
       <h1 class="hero__title">
         From lab bench
         <span class="hero__title--accent"
-          >to production-grade genomic platforms</span
+          >to production-grade data platforms</span
         >
       </h1>
       <p class="hero__lede">
-        I translate wet-lab science into production-ready genomic platforms.
+        I translate wet-lab science into production-ready data platforms.
         Building resilient infrastructure for life sciences with deep biological
         context, I've spent 5+ years automating NGS pipelines, managing research
         systems, and cutting genomic processing time by 50%. Today I run


### PR DESCRIPTION
## Summary
- replace the hero headline and lede references to genomic platforms with data platforms to reflect updated positioning

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e06ad147608333bfe9c473e5d74735