### PR TITLE
fix: adjust scientific computing highlight

### DIFF
--- a/src/components/skills/ApplicationSkills.svelte
+++ b/src/components/skills/ApplicationSkills.svelte
@@ -14,21 +14,21 @@
       id: 'scientific-computing',
       title: 'Scientific Computing',
       narrative:
-        'High-performance compute pipelines translating raw sequencer output into audit-ready biology. Automations keep terabyte-scale studies reproducible while matching the tempo of translational teams.',
+        'Production-grade compute pipelines transforming raw sequencer output into analysis-ready biology. Automated workflows keep terabyte-scale studies reproducible while matching the pace of translational research teams.',
       highlights: [
-        'Orchestrated RNA/DNA-seq and variant calling through Nextflow Tower on AWS Batch from Illumina ingest to biological readouts',
-        'Automated IC50, dose-response, and kinase inhibition analyses with Python/R pipelines enforcing statistical validation gates',
-        'Trained scikit-learn models across experimental datasets to classify responder phenotypes and predict compound efficacy',
+        'Orchestrated RNA/DNA-seq and variant calling workflows through Nextflow Tower on AWS Batch, processing high-throughput sequences from Illumina instruments to validated biological insights',
+        'Automated IC50, dose-response, and kinase inhibition analyses with Python/R pipelines featuring built-in statistical validation and quality control gates',
+        'Trained scikit-learn models on experimental datasets to classify cellular phenotypes and predict compound efficacy, integrating ML predictions into research decision workflows',
       ],
       stack: [
         { label: 'Core', detail: 'Python, R, SQL, Nextflow, Bash, statistical modeling' },
         {
           label: 'HPC & Pipelines',
-          detail: 'AWS Batch, Nextflow Tower, nf-core, Galaxy, Conda environments, Docker',
+          detail: 'AWS Batch, Nextflow Tower, nf-core workflows, Galaxy, Conda environments, Docker containerization, cloud-native computing',
         },
         {
           label: 'Analysis & Viz',
-          detail: 'GraphPad Prism, JMP, Plotly, Power BI, automated report generation, fragment analysis',
+          detail: 'GraphPad Prism, Python (pandas/scikit-learn), R, Plotly, Power BI, automated reporting, interactive dashboards',
         },
       ],
     },

--- a/src/content/home.ts
+++ b/src/content/home.ts
@@ -39,7 +39,7 @@ export const heroStats: HeroStat[] = [
   },
   {
     label: 'Scale proven in production',
-    value: '1M+ samples',
+    value: 'High-throughput runs',
     context:
       'Sequencing and analysis workloads orchestrated end-to-end without sacrificing reproducibility or compliance',
   },
@@ -139,7 +139,7 @@ export const experiences: Experience[] = [
     focus:
       'Led molecular biology operations while building computational infrastructure and web-based scientific workflow tools for high-throughput research.',
     impact: [
-      'Built automated pipelines processing 1,000,000+ genomic sequences with 50% reduction in turnaround time, orchestrating workflows across cloud infrastructure',
+      'Built automated pipelines processing large-scale genomic datasets with 50% reduction in turnaround time, orchestrating workflows across cloud infrastructure',
       'Deployed production NGS workflows on Kubernetes and AWS Batch via Nextflow Tower, managing TB-scale genomic data with Terraform-provisioned infrastructure',
       'Developed web-based scientific applications using SvelteKit and FastAPI with containerized deployments, creating custom analysis tools and interactive dashboards that streamlined biological data workflows',
       'Operated and maintained Illumina NGS platforms (iSeq100, NextSeq500), managing complete workflows from library preparation through data analysis',

--- a/tests/unit/components/skills/ApplicationSkills.spec.ts
+++ b/tests/unit/components/skills/ApplicationSkills.spec.ts
@@ -14,12 +14,12 @@ describe('ApplicationSkills', () => {
     expect(scientificButton).toHaveClass('selected');
     expect(
       screen.getByText(
-        /High-performance compute pipelines translating raw sequencer output into audit-ready biology/i,
+        /Production-grade compute pipelines transforming raw sequencer output into analysis-ready biology/i,
       ),
     ).toBeInTheDocument();
     expect(
       await screen.findByText(
-        /Orchestrated RNA\/DNA-seq and variant calling through Nextflow Tower on AWS Batch/i,
+        /Orchestrated RNA\/DNA-seq and variant calling workflows through Nextflow Tower on AWS Batch/i,
         undefined,
         { timeout: 5000 },
       ),


### PR DESCRIPTION
## Summary
- tighten the scientific computing narrative to emphasize production-grade pipelines and research velocity
- highlight controls and ml integration across scientific computing accomplishments while softening explicit sequence volume claims
- update supporting stack details to stress cloud-native tooling and analysis automation

## Testing
- pnpm build
- pnpm preview --host (manually stopped)


------
https://chatgpt.com/codex/tasks/task_e_68e0724a80a483339d33c0808ea956a1