### PR TITLE
fix: update hero stat sample count

### DIFF
--- a/src/content/home.ts
+++ b/src/content/home.ts
@@ -39,7 +39,7 @@ export const heroStats: HeroStat[] = [
   },
   {
     label: 'Scale proven in production',
-    value: 'High-throughput runs',
+    value: '1M+ samples',
     context:
       'Sequencing and analysis workloads orchestrated end-to-end without sacrificing reproducibility or compliance',
   },


### PR DESCRIPTION
## Summary
- update the production scale hero stat to display "1M+ samples" for clarity

## Testing
- pnpm build
- pnpm type-check

------
https://chatgpt.com/codex/tasks/task_e_68e07b47bad4833385ef5102d442d4b6