### PR TITLE
fix: update quality standards summary

### DIFF
--- a/src/components/skills/ApplicationSkills.svelte
+++ b/src/components/skills/ApplicationSkills.svelte
@@ -94,7 +94,10 @@
           detail:
             'Requirements gathering, user training, technical documentation, cross-functional coordination, iterative feedback loops',
         },
-        { label: 'Quality Standards', detail: 'GLP practices, CLIA/CAP familiarity, validated workflows, reproducible analysis' },
+        {
+          label: 'Quality Standards',
+          detail: 'Validated workflows, audit-ready documentation, reproducible analysis',
+        },
         { label: 'Enablement', detail: 'Technical mentoring, workflow automation, data visualization, client-focused tool development' },
       ],
     },


### PR DESCRIPTION
## Summary
- update the Quality Standards description in the application skills component to remove GLP and CLIA/CAP references while highlighting validated workflows, audit-ready documentation, and reproducible analysis

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e0abe4d0c08333ac7096cd540faa75