### PR TITLE
test: stabilize home page e2e selectors

### DIFF
--- a/src/components/home/ContactSection.astro
+++ b/src/components/home/ContactSection.astro
@@ -8,11 +8,16 @@ interface Props {
 const { channels } = Astro.props as Props;
 ---
 
-<section class="section section--contact" id="contact" data-reveal>
-  <div class="u-container contact">
-    <div class="contact__intro">
+<section
+  class="section section--contact"
+  id="contact"
+  data-reveal
+  data-testid="contact-section"
+>
+  <div class="u-container contact" data-testid="contact-layout">
+    <div class="contact__intro" data-testid="contact-intro">
       <p class="u-title-overline">Contact</p>
-      <h2>
+      <h2 data-testid="contact-heading">
         Scale your genomics infrastructure without losing scientific rigor
       </h2>
       <p>
@@ -52,9 +57,15 @@ const { channels } = Astro.props as Props;
         </ul>
       </div>
     </div>
-    <aside class="contact__panel" aria-labelledby="contact-panel-title">
-      <div class="contact-card">
-        <h3 id="contact-panel-title">Start a conversation</h3>
+    <aside
+      class="contact__panel"
+      aria-labelledby="contact-panel-title"
+      data-testid="contact-panel"
+    >
+      <div class="contact-card" data-testid="contact-card">
+        <h3 id="contact-panel-title" data-testid="contact-panel-heading">
+          Start a conversation
+        </h3>
         <p class="contact-card__intro">
           Share whether you're scaling NGS workflows, modernizing lab
           infrastructure, or automating data pipelines and I'll reply with

--- a/src/components/home/ExperienceSection.astro
+++ b/src/components/home/ExperienceSection.astro
@@ -9,11 +9,17 @@ interface Props {
 const { experiences } = Astro.props as Props;
 ---
 
-<section class="section" id="experience" data-reveal>
+<section
+  class="section"
+  id="experience"
+  data-reveal
+  data-testid="experience-section"
+>
   <SectionHeader
     overline="Experience"
     title="Career progression from research to technical operations leadership"
     description="Roles span academic research, biotechnology, and healthcare IT. Each position strengthened the bridge between scientific discovery and scalable technical implementation."
+    testId="experience-header"
   />
   <div class="u-container experience">
     {

--- a/src/components/home/HeroSection.astro
+++ b/src/components/home/HeroSection.astro
@@ -8,11 +8,11 @@ interface Props {
 const { stats } = Astro.props as Props;
 ---
 
-<section class="hero" id="hero" data-reveal>
-  <div class="u-container hero__inner">
-    <div class="hero__copy">
-      <p class="hero__name">Shyam Ajudia</p>
-      <h1 class="hero__title">
+<section class="hero" id="hero" data-reveal data-testid="hero-section">
+  <div class="u-container hero__inner" data-testid="hero-layout">
+    <div class="hero__copy" data-testid="hero-copy">
+      <p class="hero__name" data-testid="hero-name">Shyam Ajudia</p>
+      <h1 class="hero__title" data-testid="hero-title">
         From lab bench
         <span class="hero__title--accent"
           >to production-grade data platforms</span
@@ -28,9 +28,11 @@ const { stats } = Astro.props as Props;
         My wet-lab background means I don't just deploy infrastructure—I understand
         the experiments running on it.
       </p>
-      <div class="hero__actions">
-        <a class="hero__cta" href="#contact">Collaborate</a>
-        <a class="hero__scroll" href="#experience">
+      <div class="hero__actions" data-testid="hero-actions">
+        <a class="hero__cta" href="#contact" data-testid="hero-cta"
+          >Collaborate</a
+        >
+        <a class="hero__scroll" href="#experience" data-testid="hero-see-more">
           <span>See more</span>
           <svg aria-hidden="true" viewBox="0 0 24 24" role="presentation">
             <path
@@ -51,10 +53,10 @@ const { stats } = Astro.props as Props;
         </a>
       </div>
     </div>
-    <div class="hero__metrics anim-stagger">
+    <div class="hero__metrics anim-stagger" data-testid="hero-metrics">
       {
         stats.map((stat) => (
-          <article class="hero__metric">
+          <article class="hero__metric" data-testid="hero-metric">
             <h2>{stat.value}</h2>
             <p>{stat.label}</p>
             <span>{stat.context}</span>

--- a/src/components/home/HomeHeader.astro
+++ b/src/components/home/HomeHeader.astro
@@ -3,15 +3,20 @@ import MobileNavInitializer from '../scripts/MobileNavInitializer.svelte';
 import ThemeToggle from '../ui/ThemeToggle.svelte';
 
 const navLinks = [
-  { label: 'Overview', href: '#hero' },
-  { label: 'Experience', href: '#experience' },
-  { label: 'Projects', href: '#projects' },
-  { label: 'Skills', href: '#skills' },
-  { label: 'Contact', href: '#contact' },
+  { label: 'Overview', href: '#hero', id: 'overview' },
+  { label: 'Experience', href: '#experience', id: 'experience' },
+  { label: 'Projects', href: '#projects', id: 'projects' },
+  { label: 'Skills', href: '#skills', id: 'skills' },
+  { label: 'Contact', href: '#contact', id: 'contact' },
 ];
 ---
 
-<header class="site-header" data-reveal data-js="site-header">
+<header
+  class="site-header"
+  data-reveal
+  data-js="site-header"
+  data-testid="site-header"
+>
   <div class="site-header__inner u-container">
     <button
       class="site-nav__toggle"
@@ -21,6 +26,7 @@ const navLinks = [
       aria-label="Open navigation menu"
       data-js="nav-toggle"
       data-state="closed"
+      data-testid="primary-nav-toggle"
     >
       <span class="site-nav__toggle-icon" aria-hidden="true">
         <span class="site-nav__toggle-line"></span>
@@ -36,10 +42,15 @@ const navLinks = [
       aria-label="Primary navigation"
       data-js="primary-navigation"
       data-state="open"
+      data-testid="primary-navigation"
     >
       {
         navLinks.map((link) => (
-          <a class="site-nav__link" href={link.href}>
+          <a
+            class="site-nav__link"
+            href={link.href}
+            data-testid={`primary-nav-link-${link.id}`}
+          >
             {link.label}
           </a>
         ))

--- a/src/components/home/ProjectCard.astro
+++ b/src/components/home/ProjectCard.astro
@@ -17,7 +17,11 @@ const details = getProjectDetails(project);
     switch (project.layout) {
       case 'wide':
         return (
-          <article class="project-card project-card--wide u-glass" data-reveal>
+          <article
+            class="project-card project-card--wide u-glass"
+            data-reveal
+            data-testid="project-card"
+          >
             <ProjectCardHeader project={project} />
             <div class="project-card__content">
               <div>
@@ -42,7 +46,11 @@ const details = getProjectDetails(project);
               />
             </div>
             {project.link && (
-              <a class="project-card__link" href={project.link}>
+              <a
+                class="project-card__link"
+                href={project.link}
+                data-testid="project-source-link"
+              >
                 Source code →
               </a>
             )}
@@ -50,7 +58,11 @@ const details = getProjectDetails(project);
         );
       case 'standard':
         return (
-          <article class="project-card project-card--standard" data-reveal>
+          <article
+            class="project-card project-card--standard"
+            data-reveal
+            data-testid="project-card"
+          >
             <ProjectCardHeader project={project} />
             <dl>
               <div>
@@ -69,7 +81,11 @@ const details = getProjectDetails(project);
               />
             </div>
             {project.link && (
-              <a class="project-card__link" href={project.link}>
+              <a
+                class="project-card__link"
+                href={project.link}
+                data-testid="project-source-link"
+              >
                 Source code →
               </a>
             )}
@@ -77,7 +93,11 @@ const details = getProjectDetails(project);
         );
       case 'tall':
         return (
-          <article class="project-card project-card--tall" data-reveal>
+          <article
+            class="project-card project-card--tall"
+            data-reveal
+            data-testid="project-card"
+          >
             <ProjectCardHeader project={project} />
             <div class="project-card__meta">
               <h4>Problem</h4>
@@ -92,7 +112,11 @@ const details = getProjectDetails(project);
               />
             </div>
             {project.link && (
-              <a class="project-card__link" href={project.link}>
+              <a
+                class="project-card__link"
+                href={project.link}
+                data-testid="project-source-link"
+              >
                 Source code →
               </a>
             )}

--- a/src/components/home/ProjectsSection.astro
+++ b/src/components/home/ProjectsSection.astro
@@ -10,14 +10,20 @@ interface Props {
 const { projects } = Astro.props as Props;
 ---
 
-<section class="section projects" id="projects" data-reveal>
+<section
+  class="section projects"
+  id="projects"
+  data-reveal
+  data-testid="projects-section"
+>
   <SectionHeader
     overline="Featured Projects"
     title="Hybrid services connecting lab work to cloud scale"
     description="Core infrastructure services keep my platform running: the GitOps Kubernetes platform, this portfolio, and the immutable operating system that keeps my personal desktop reproducible."
+    testId="projects-header"
   />
 
-  <div class="u-container projects__grid">
+  <div class="u-container projects__grid" data-testid="projects-grid">
     {projects.map((project) => <ProjectCard project={project} />)}
   </div>
 </section>

--- a/src/components/home/SkillsSection.astro
+++ b/src/components/home/SkillsSection.astro
@@ -3,11 +3,12 @@ import ApplicationSkills from '../skills/ApplicationSkills.svelte';
 import SectionHeader from '../ui/SectionHeader.astro';
 ---
 
-<section class="section" id="skills" data-reveal>
+<section class="section" id="skills" data-reveal data-testid="skills-section">
   <SectionHeader
     overline="Skill Architecture"
     title="Capabilities organised by scientific outcome"
     description="Choose a lens—scientific computing, infrastructure, data, collaboration—to see how tooling decisions connect directly to scientific velocity and compliance."
+    testId="skills-header"
   />
   <div class="u-container">
     <ApplicationSkills client:visible />

--- a/src/components/ui/SectionHeader.astro
+++ b/src/components/ui/SectionHeader.astro
@@ -3,12 +3,13 @@ interface Props {
   overline: string;
   title: string;
   description?: string;
+  testId?: string;
 }
 
-const { overline, title, description } = Astro.props as Props;
+const { overline, title, description, testId } = Astro.props as Props;
 ---
 
-<div class="u-container section__heading">
+<div class="u-container section__heading" data-testid={testId}>
   <div>
     <p class="u-title-overline">{overline}</p>
     <h2>{title}</h2>

--- a/tests/e2e/components.spec.ts
+++ b/tests/e2e/components.spec.ts
@@ -10,7 +10,9 @@ test.describe('Home page experience', () => {
     await expect(page.locator('html')).toHaveAttribute('lang', 'en');
 
     const header = page.getByTestId('site-header');
-    await expect(header).toBeVisible();
+    await expect(header).toBeAttached();
+    await expect(header).toHaveClass(/site-header/);
+    await expect(header).toHaveAttribute('data-js', 'site-header');
 
     const navigation = page.getByTestId('primary-navigation');
     const navToggle = page.getByTestId('primary-nav-toggle');

--- a/tests/e2e/components.spec.ts
+++ b/tests/e2e/components.spec.ts
@@ -9,13 +9,11 @@ test.describe('Home page experience', () => {
   test('renders hero content and site navigation', async ({ page }) => {
     await expect(page.locator('html')).toHaveAttribute('lang', 'en');
 
-    const header = page.locator('.site-header');
-    await expect(header).toHaveAttribute('data-js', 'site-header');
+    const header = page.getByTestId('site-header');
+    await expect(header).toBeVisible();
 
-    const navigation = page.getByRole('navigation', {
-      name: 'Primary navigation',
-    });
-    const navToggle = page.locator('[data-js="nav-toggle"]');
+    const navigation = page.getByTestId('primary-navigation');
+    const navToggle = page.getByTestId('primary-nav-toggle');
 
     if (await navToggle.isVisible()) {
       await navToggle.click();
@@ -24,25 +22,25 @@ test.describe('Home page experience', () => {
       await expect(navigation).toBeVisible();
     }
 
-    const navLabels = [
-      'Overview',
-      'Experience',
-      'Projects',
-      'Skills',
-      'Contact',
+    const navLinkIds = [
+      'overview',
+      'experience',
+      'projects',
+      'skills',
+      'contact',
     ];
 
-    for (const label of navLabels) {
-      await expect(navigation.getByRole('link', { name: label })).toBeVisible();
+    for (const id of navLinkIds) {
+      await expect(page.getByTestId(`primary-nav-link-${id}`)).toBeVisible();
     }
 
-    await expect(page.locator('.hero__title')).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Collaborate' })).toBeVisible();
-    const seeMoreLink = page.getByRole('link', { name: 'See more' });
+    await expect(page.getByTestId('hero-title')).toBeVisible();
+    await expect(page.getByTestId('hero-cta')).toBeVisible();
+    const seeMoreLink = page.getByTestId('hero-see-more');
     await expect(seeMoreLink).toBeVisible();
     await expect(seeMoreLink).toHaveAttribute('href', '#experience');
 
-    await expect(page.locator('.hero__metric')).toHaveCount(3);
+    await expect(page.getByTestId('hero-metric')).toHaveCount(3);
   });
 
   test('supports toggling primary navigation on small screens', async ({
@@ -51,13 +49,11 @@ test.describe('Home page experience', () => {
     await page.setViewportSize({ width: 480, height: 900 });
     await page.reload();
 
-    const toggle = page.getByRole('button', { name: /navigation menu/i });
+    const toggle = page.getByTestId('primary-nav-toggle');
     await expect(toggle).toBeVisible();
     await expect(toggle).toHaveAttribute('aria-expanded', 'false');
 
-    const navigation = page.getByRole('navigation', {
-      name: 'Primary navigation',
-    });
+    const navigation = page.getByTestId('primary-navigation');
     await expect(navigation).not.toBeVisible();
 
     await toggle.click();
@@ -65,21 +61,21 @@ test.describe('Home page experience', () => {
     await expect(toggle).toHaveAccessibleName(/close navigation menu/i);
     await expect(navigation).toBeVisible();
 
-    await page.getByRole('link', { name: 'Projects' }).click();
+    await page.getByTestId('primary-nav-link-projects').click();
     await expect(toggle).toHaveAttribute('aria-expanded', 'false');
     await expect(toggle).toHaveAccessibleName(/open navigation menu/i);
     await expect(navigation).not.toBeVisible();
   });
 
   test('displays featured projects', async ({ page }) => {
-    const projectsSection = page.locator('#projects');
+    const projectsSection = page.getByTestId('projects-section');
     await projectsSection.scrollIntoViewIfNeeded();
     await expect(projectsSection).toBeVisible();
 
-    await expect(page.locator('.projects__grid .project-card')).toHaveCount(3);
-    const sourceLinks = projectsSection.getByRole('link', {
-      name: 'Source code →',
-    });
+    await expect(
+      page.getByTestId('projects-grid').getByTestId('project-card'),
+    ).toHaveCount(3);
+    const sourceLinks = page.getByTestId('project-source-link');
     await expect(sourceLinks).toHaveCount(3);
     for (const index of [0, 1, 2]) {
       await expect(sourceLinks.nth(index)).toBeVisible();
@@ -89,37 +85,28 @@ test.describe('Home page experience', () => {
   test('highlights skills, experience, and contact sections', async ({
     page,
   }) => {
-    const skills = page.locator('#skills');
+    const skills = page.getByTestId('skills-section');
     await skills.scrollIntoViewIfNeeded();
     await expect(skills).toBeVisible();
-    await expect(
-      page.getByRole('heading', { name: /Capabilities organised/i }),
-    ).toBeVisible();
+    await expect(page.getByTestId('skills-header')).toBeVisible();
 
-    const experience = page.locator('#experience');
+    const experience = page.getByTestId('experience-section');
     await experience.scrollIntoViewIfNeeded();
     await expect(experience).toBeVisible();
-    await expect(
-      page.getByRole('heading', {
-        name: /Career progression from research to technical operations leadership/i,
-      }),
-    ).toBeVisible();
+    await expect(page.getByTestId('experience-header')).toBeVisible();
 
-    const contact = page.locator('#contact');
+    const contact = page.getByTestId('contact-section');
     await contact.scrollIntoViewIfNeeded();
     await expect(contact).toBeVisible();
-    await expect(
-      page.getByRole('heading', {
-        name: /Scale your genomics infrastructure without losing scientific rigor/i,
-      }),
-    ).toBeVisible();
+    await expect(page.getByTestId('contact-heading')).toBeVisible();
+    await expect(page.getByTestId('contact-card')).toBeVisible();
   });
 
   test('persists theme preference across reloads', async ({ page }) => {
     const html = page.locator('html');
     const initialTheme = (await html.getAttribute('data-theme')) ?? 'light';
 
-    const navToggle = page.locator('[data-js="nav-toggle"]');
+    const navToggle = page.getByTestId('primary-nav-toggle');
     if (await navToggle.isVisible()) {
       await navToggle.click();
     }


### PR DESCRIPTION
## Summary
- add stable data-testid hooks across the hero, navigation, projects, skills, experience, and contact sections
- extend SectionHeader with optional test identifiers to expose consistent selectors
- update the home page e2e spec to target the new hooks instead of marketing copy

## Testing
- pnpm test:e2e -- tests/e2e/components.spec.ts *(fails: Playwright browsers missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b35b46bc8333b8c4bf578958167e