### PR TITLE
test: cover mobile nav dismissal

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,7 +19,7 @@ import '../styles/pages/home.css';
 <BaseLayout>
   <HomeHeader />
 
-  <main>
+  <main data-testid="page-main">
     <HeroSection stats={heroStats} />
     <ExperienceSection experiences={experiences} />
     <ProjectsSection projects={projects} />

--- a/tests/e2e/components.spec.ts
+++ b/tests/e2e/components.spec.ts
@@ -69,6 +69,29 @@ test.describe('Home page experience', () => {
     await expect(navigation).not.toBeVisible();
   });
 
+  test('closes primary navigation when tapping outside on small screens', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 480, height: 900 });
+    await page.reload();
+
+    const toggle = page.getByTestId('primary-nav-toggle');
+    const navigation = page.getByTestId('primary-navigation');
+    const pageMain = page.getByTestId('page-main');
+
+    await expect(toggle).toBeVisible();
+    await expect(navigation).not.toBeVisible();
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(navigation).toBeVisible();
+
+    await pageMain.click({ position: { x: 10, y: 10 } });
+
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(navigation).toBeHidden();
+  });
+
   test('displays featured projects', async ({ page }) => {
     const projectsSection = page.getByTestId('projects-section');
     await projectsSection.scrollIntoViewIfNeeded();


### PR DESCRIPTION
## Summary
- add a stable data-testid hook to the home page main content for interaction tests
- extend the mobile navigation e2e coverage to assert the menu closes after tapping outside

## Testing
- pnpm test:e2e *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e43da7fa3c8333bae8cecfe27f0bfb